### PR TITLE
VCST-4552: Use docker for graphql and e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,54 +5,24 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Frontend zip url'
+        required: true
+        type: string
+        default: 'https://github.com/VirtoCommerce/vc-frontend/releases/download/2.39.0/vc-theme-b2b-vue-2.39.0.zip'
 
 jobs:
   e2e-tests:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [webkit] #chromium, firefox
-
-    env:
-      FRONTEND_BASE_URL: https://vcptcore-demo-storefront.govirto.com
-      BACKEND_BASE_URL: https://vcptcore-demo.govirto.com
-      ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
-      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
-      USERS_PASSWORD: ${{ secrets.USERS_PASSWORD }}
-      STORE_ID: store-acme      
-      PLAYWRIGHT_HEADLESS: "true"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13.7"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest-html
-
-      - name: Install Playwright Browsers
-        run: playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run E2E Tests
-        run: |
-          echo "Running E2E tests against ${{ env.FRONTEND_BASE_URL }}"
-          pytest tests_e2e/tests/ -v -s --checkout-mode single-page --product-quantity-control stepper -m "not ignore" --browser ${{ matrix.browser }} --html=e2e-report.html --self-contained-html --tracing=retain-on-failure
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-test-results-${{ matrix.browser }}
-          path: |
-            e2e-report.html
-            playwright-report/
-            test-results/
-          retention-days: 30
+    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.22
+    with:
+      installModules: 'false'
+      installCustomModule: 'false'
+      runTests: 'true'
+      vctestingRepoBranch: '${{ github.ref_name }}'
+      frontendZipUrl: '${{ inputs.version }}'
+      customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/backend-packages.json'
+    secrets:
+      envPAT: ${{ secrets.REPO_TOKEN }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, 'VCST-455']
   pull_request:
     branches: [dev]
   workflow_dispatch:

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,0 +1,334 @@
+{
+    "ManifestVersion": "2.0",
+    "PlatformVersion": "3.915.0",
+    "ThemeB2BVue": "https://github.com/VirtoCommerce/vc-frontend/releases/download/2.21.0/vc-theme-b2b-vue-2.21.0.zip",
+    "PlatformImage": "ghcr.io/virtocommerce/platform",
+    "PlatformImageTag": "3.887.8",
+    "PlatformAssetUrl": "",
+    "BundleVersion": "11.0.3",
+    "Sources": [
+        {
+            "Name": "AzureBlob",
+            "Container": "packages",
+            "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
+            "Modules": [
+                {
+                    "Id": "VirtoCommerce.PageBuilderModule",
+                    "BlobName": "VirtoCommerce.PageBuilderModule_3.828.0-alpha.745-dev.zip"
+                }
+            ]
+        },
+        {
+            "Name": "GithubReleases",
+            "ModuleSources": [
+                "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
+            ],
+            "Modules": [
+                {
+                    "Id": "VirtoCommerce.ApplicationInsights",
+                    "Version": "3.806.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Assets",
+                    "Version": "3.813.0"
+                },
+                {
+                    "Id": "VirtoCommerce.AuthorizeNetPayment",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.AvalaraTax",
+                    "Version": "3.804.0"
+                },
+                {
+                    "Id": "VirtoCommerce.AzureAD",
+                    "Version": "3.804.0"
+                },
+                {
+                    "Id": "VirtoCommerce.AzureBlobAssets",
+                    "Version": "3.811.0"
+                },
+                {
+                    "Id": "VirtoCommerce.AzureSearch",
+                    "Version": "3.808.0"
+                },
+                {
+                    "Id": "VirtoCommerce.BackInStock",
+                    "Version": "3.804.0"
+                },
+                {
+                    "Id": "VirtoCommerce.BuilderIO",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.BulkActionsModule",
+                    "Version": "3.804.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Cart",
+                    "Version": "3.839.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Catalog",
+                    "Version": "3.902.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CatalogCsvImportModule",
+                    "Version": "3.816.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CatalogPersonalization",
+                    "Version": "3.807.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CatalogPublishing",
+                    "Version": "3.808.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Content",
+                    "Version": "3.830.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Contentful",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Contracts",
+                    "Version": "3.905.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Core",
+                    "Version": "3.822.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Customer",
+                    "Version": "3.845.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CustomerExportImport",
+                    "Version": "3.814.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CustomerReviews",
+                    "Version": "3.906.0"
+                },
+                {
+                    "Id": "VirtoCommerce.CyberSourcePayment",
+                    "Version": "3.802.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Datatrans",
+                    "Version": "3.800.0"
+                },
+                {
+                    "Id": "VirtoCommerce.DynamicAssociationsModule",
+                    "Version": "3.810.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ElasticAppSearch",
+                    "Version": "3.815.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ElasticSearch",
+                    "Version": "3.806.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ElasticSearch8",
+                    "Version": "3.822.0"
+                },
+                {
+                    "Id": "VirtoCommerce.EventBus",
+                    "Version": "3.808.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Export",
+                    "Version": "3.807.0"
+                },
+                {
+                    "Id": "VirtoCommerce.FileExperienceApi",
+                    "Version": "3.905.0"
+                },
+                {
+                    "Id": "VirtoCommerce.FileSystemAssets",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.GDPR",
+                    "Version": "3.808.0"
+                },
+                {
+                    "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
+                    "Version": "4.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.GoogleSSO",
+                    "Version": "3.803.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ImageTools",
+                    "Version": "3.812.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Inventory",
+                    "Version": "3.814.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Loyalty",
+                    "Version": "3.800.0"
+                },
+                {
+                    "Id": "VirtoCommerce.LuceneSearch",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Marketing",
+                    "Version": "3.823.0"
+                },
+                {
+                    "Id": "VirtoCommerce.MarketingExperienceApi",
+                    "Version": "3.901.0"
+                },
+                {
+                    "Id": "VirtoCommerce.NativePaymentMethods",
+                    "Version": "3.802.0"
+                },
+                {
+                    "Id": "VirtoCommerce.News",
+                    "Version": "3.812.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Notifications",
+                    "Version": "3.827.0"
+                },
+                {
+                    "Id": "VirtoCommerce.OpenIdConnectModule",
+                    "Version": "3.802.0"
+                },
+                {
+                    "Id": "VirtoCommerce.OpenSearch",
+                    "Version": "3.801.0"
+                },
+                {
+                    "Id": "VirtoCommerce.OrderManagement",
+                    "Version": "3.807.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Orders",
+                    "Version": "3.862.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Pages",
+                    "Version": "3.809.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Payment",
+                    "Version": "3.810.0"
+                },
+                {
+                    "Id": "VirtoCommerce.PriceExportImport",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Pricing",
+                    "Version": "3.821.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ProfileExperienceApiModule",
+                    "Version": "3.923.0"
+                },
+                {
+                    "Id": "VirtoCommerce.PushMessages",
+                    "Version": "3.905.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Quote",
+                    "Version": "3.912.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Return",
+                    "Version": "3.812.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Search",
+                    "Version": "3.819.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Seo",
+                    "Version": "3.809.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Shipping",
+                    "Version": "3.815.0"
+                },
+                {
+                    "Id": "VirtoCommerce.ShipStation",
+                    "Version": "3.801.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Sitemaps",
+                    "Version": "3.819.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Skyflow",
+                    "Version": "3.901.0"
+                },
+                {
+                    "Id": "VirtoCommerce.SqlQueries",
+                    "Version": "3.801.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Store",
+                    "Version": "3.822.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Subscription",
+                    "Version": "3.810.0"
+                },
+                {
+                    "Id": "VirtoCommerce.TaskManagement",
+                    "Version": "3.904.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Tax",
+                    "Version": "3.805.0"
+                },
+                {
+                    "Id": "VirtoCommerce.WebHooks",
+                    "Version": "3.809.0"
+                },
+                {
+                    "Id": "VirtoCommerce.WhiteLabeling",
+                    "Version": "3.908.0"
+                },
+                {
+                    "Id": "VirtoCommerce.Xapi",
+                    "Version": "3.926.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XCart",
+                    "Version": "3.947.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XCatalog",
+                    "Version": "3.941.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XCMS",
+                    "Version": "3.902.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XOrder",
+                    "Version": "3.913.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XPickup",
+                    "Version": "3.802.0"
+                },
+                {
+                    "Id": "VirtoCommerce.XRecommend",
+                    "Version": "3.904.0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the inline Playwright-based E2E job with a reusable workflow and introduces a backend packages manifest for test environments.
> 
> - Updates `e2e-tests.yml` to use `VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.22`; adds manual `workflow_dispatch` with `version` input for a frontend zip
> - Provides inputs (`installModules`, `installCustomModule`, `runTests`, `vctestingRepoBranch`, `frontendZipUrl`, `customPackagesJsonUrl`) and required secrets (`envPAT`, `testSecretEnvFile`)
> - Adds `backend-packages.json` defining platform image/tag and module sources/versions (incl. `PageBuilderModule` from AzureBlob) referenced by the workflow via `customPackagesJsonUrl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d7e5c238aa23d96c41604de0611016be996e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->