### PR TITLE
feat: add E2E tests for product pickup locations modal

### DIFF
--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,343 +1,335 @@
+
 {
-    "ManifestVersion": "2.0",
-    "PlatformVersion": "3.1004.0",
-    "PlatformImage": "ghcr.io/virtocommerce/platform",
-    "PlatformImageTag": "3.1004.0",
-    "PlatformAssetUrl": "",
-    "ModuleSources": [
-        "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
-    ],
-    "Sources": [
+  "ManifestVersion": "2.0",
+  "PlatformVersion": "3.1004.0",
+  "PlatformImage": "ghcr.io/virtocommerce/platform",
+  "PlatformImageTag": "3.1004.0",
+  "PlatformAssetUrl": "",
+  "ModuleSources": ["https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"],
+  "Sources": [
+    {
+      "Name": "AzureBlob",
+      "Container": "packages",
+      "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
+      "Modules": [
         {
-            "Name": "AzureBlob",
-            "Container": "packages",
-            "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-            "Modules": [
-                {
-                    "Id": "VirtoCommerce.PageBuilderModule",
-                    "BlobName": "VirtoCommerce.PageBuilderModule_3.835.0.zip"
-                }
-            ]
+          "BlobName": "VirtoCommerce.PageBuilderModule_3.835.0-pr-94-6d94.zip"
+        }
+      ]
+    },
+    {
+      "Name": "GithubReleases",
+      "ModuleSources": ["https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"],
+      "Modules": [
+        {
+          "Id": "VirtoCommerce.Contentful",
+          "Version": "3.805.0"
         },
         {
-            "Name": "GithubReleases",
-            "ModuleSources": [
-                "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
-            ],
-            "Modules": [
-                {
-                    "Id": "VirtoCommerce.Contentful",
-                    "Version": "3.805.0"
-                },
-                {
-                    "Id": "VirtoCommerce.NativePaymentMethods",
-                    "Version": "3.802.0"
-                },
-                {
-                    "Id": "VirtoCommerce.MarketingExperienceApi",
-                    "Version": "3.901.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Skyflow",
-                    "Version": "3.901.0"
-                },
-                {
-                    "Id": "VirtoCommerce.WhiteLabeling",
-                    "Version": "3.908.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XRecommend",
-                    "Version": "3.904.0"
-                },
-                {
-                    "Id": "VirtoCommerce.OpenSearch",
-                    "Version": "3.801.0"
-                },
-                {
-                    "Id": "VirtoCommerce.PriceExportImport",
-                    "Version": "3.805.0"
-                },
-                {
-                    "Id": "VirtoCommerce.News",
-                    "Version": "3.812.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CustomerExportImport",
-                    "Version": "3.814.0"
-                },
-                {
-                    "Id": "VirtoCommerce.BackInStock",
-                    "Version": "3.804.0"
-                },
-                {
-                    "Id": "VirtoCommerce.OrderManagement",
-                    "Version": "3.807.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Datatrans",
-                    "Version": "3.800.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ElasticSearch",
-                    "Version": "3.806.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ShipStation",
-                    "Version": "3.802.0"
-                },
-                {
-                    "Id": "VirtoCommerce.TaskManagement",
-                    "Version": "3.905.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XPickup",
-                    "Version": "3.804.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ApplicationInsights",
-                    "Version": "3.807.0"
-                },
-                {
-                    "Id": "VirtoCommerce.AzureAD",
-                    "Version": "3.805.0"
-                },
-                {
-                    "Id": "VirtoCommerce.GoogleSSO",
-                    "Version": "3.804.0"
-                },
-                {
-                    "Id": "VirtoCommerce.AzureSearch",
-                    "Version": "3.809.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ElasticAppSearch",
-                    "Version": "3.816.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Pages",
-                    "Version": "3.811.0"
-                },
-                {
-                    "Id": "VirtoCommerce.AzureBlobAssets",
-                    "Version": "3.813.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Sitemaps",
-                    "Version": "3.822.0"
-                },
-                {
-                    "Id": "VirtoCommerce.AuthorizeNetPayment",
-                    "Version": "3.806.0"
-                },
-                {
-                    "Id": "VirtoCommerce.GDPR",
-                    "Version": "3.809.0"
-                },
-                {
-                    "Id": "VirtoCommerce.AvalaraTax",
-                    "Version": "3.805.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Return",
-                    "Version": "3.813.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Quote",
-                    "Version": "3.913.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CustomerReviews",
-                    "Version": "3.907.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XFrontend",
-                    "Version": "3.800.0"
-                },
-                {
-                    "Id": "VirtoCommerce.BuilderIO",
-                    "Version": "3.807.0"
-                },
-                {
-                    "Id": "VirtoCommerce.LuceneSearch",
-                    "Version": "3.807.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CyberSourcePayment",
-                    "Version": "3.803.0"
-                },
-                {
-                    "Id": "VirtoCommerce.PushMessages",
-                    "Version": "3.907.0"
-                },
-                {
-                    "Id": "VirtoCommerce.SqlQueries",
-                    "Version": "3.803.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Subscription",
-                    "Version": "3.813.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Customer",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XCMS",
-                    "Version": "3.908.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Xapi",
-                    "Version": "3.1001.0"
-                },
-                {
-                    "Id": "VirtoCommerce.FileExperienceApi",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ProfileExperienceApiModule",
-                    "Version": "3.928.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Search",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ElasticSearch8",
-                    "Version": "3.825.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XCatalog",
-                    "Version": "3.945.0"
-                },
-                {
-                    "Id": "VirtoCommerce.WebHooks",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Seo",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.EventBus",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XOrder",
-                    "Version": "3.916.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Store",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.OpenIdConnectModule",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Export",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.BulkActionsModule",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.ImageTools",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Catalog",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Inventory",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Pricing",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CatalogCsvImportModule",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CatalogPersonalization",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Payment",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Shipping",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Notifications",
-                    "Version": "3.1001.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Tax",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Cart",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Orders",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Assets",
-                    "Version": "3.1001.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Core",
-                    "Version": "3.1001.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Marketing",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.DynamicAssociationsModule",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.FileSystemAssets",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.EnvironmentsCompare",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Content",
-                    "Version": "3.838.0"
-                },
-                {
-                    "Id": "VirtoCommerce.CatalogPublishing",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.XCart",
-                    "Version": "3.953.0"
-                },
-                {
-                    "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
-                    "Version": "4.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Contracts",
-                    "Version": "3.1000.0"
-                },
-                {
-                    "Id": "VirtoCommerce.Loyalty",
-                    "Version": "3.800.0"
-                }
-            ]
+          "Id": "VirtoCommerce.NativePaymentMethods",
+          "Version": "3.802.0"
+        },
+        {
+          "Id": "VirtoCommerce.MarketingExperienceApi",
+          "Version": "3.901.0"
+        },
+        {
+          "Id": "VirtoCommerce.Skyflow",
+          "Version": "3.901.0"
+        },
+        {
+          "Id": "VirtoCommerce.XRecommend",
+          "Version": "3.904.0"
+        },
+        {
+          "Id": "VirtoCommerce.OpenSearch",
+          "Version": "3.801.0"
+        },
+        {
+          "Id": "VirtoCommerce.PriceExportImport",
+          "Version": "3.805.0"
+        },
+        {
+          "Id": "VirtoCommerce.News",
+          "Version": "3.812.0"
+        },
+        {
+          "Id": "VirtoCommerce.CustomerExportImport",
+          "Version": "3.814.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackInStock",
+          "Version": "3.804.0"
+        },
+        {
+          "Id": "VirtoCommerce.OrderManagement",
+          "Version": "3.807.0"
+        },
+        {
+          "Id": "VirtoCommerce.Datatrans",
+          "Version": "3.800.0"
+        },
+        {
+          "Id": "VirtoCommerce.ElasticSearch",
+          "Version": "3.806.0"
+        },
+        {
+          "Id": "VirtoCommerce.ShipStation",
+          "Version": "3.802.0"
+        },
+        {
+          "Id": "VirtoCommerce.TaskManagement",
+          "Version": "3.905.0"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
+          "Version": "3.804.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureAD",
+          "Version": "3.805.0"
+        },
+        {
+          "Id": "VirtoCommerce.GoogleSSO",
+          "Version": "3.804.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureSearch",
+          "Version": "3.809.0"
+        },
+        {
+          "Id": "VirtoCommerce.ElasticAppSearch",
+          "Version": "3.816.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pages",
+          "Version": "3.811.0"
+        },
+        {
+          "Id": "VirtoCommerce.GDPR",
+          "Version": "3.809.0"
+        },
+        {
+          "Id": "VirtoCommerce.AvalaraTax",
+          "Version": "3.805.0"
+        },
+        {
+          "Id": "VirtoCommerce.Quote",
+          "Version": "3.913.0"
+        },
+        {
+          "Id": "VirtoCommerce.CustomerReviews",
+          "Version": "3.907.0"
+        },
+        {
+          "Id": "VirtoCommerce.XFrontend",
+          "Version": "3.800.0"
+        },
+        {
+          "Id": "VirtoCommerce.BuilderIO",
+          "Version": "3.807.0"
+        },
+        {
+          "Id": "VirtoCommerce.CyberSourcePayment",
+          "Version": "3.803.0"
+        },
+        {
+          "Id": "VirtoCommerce.PushMessages",
+          "Version": "3.907.0"
+        },
+        {
+          "Id": "VirtoCommerce.SqlQueries",
+          "Version": "3.803.0"
+        },
+        {
+          "Id": "VirtoCommerce.Subscription",
+          "Version": "3.813.0"
+        },
+        {
+          "Id": "VirtoCommerce.Customer",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCMS",
+          "Version": "3.908.0"
+        },
+        {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileExperienceApi",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProfileExperienceApiModule",
+          "Version": "3.928.0"
+        },
+        {
+          "Id": "VirtoCommerce.Search",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.ElasticSearch8",
+          "Version": "3.825.0"
+        },
+        {
+          "Id": "VirtoCommerce.WebHooks",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Seo",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.EventBus",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.XOrder",
+          "Version": "3.916.0"
+        },
+        {
+          "Id": "VirtoCommerce.Store",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.OpenIdConnectModule",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Export",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.BulkActionsModule",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.ImageTools",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Inventory",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pricing",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogPersonalization",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Payment",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Shipping",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Notifications",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Tax",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Cart",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Assets",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Core",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Marketing",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.DynamicAssociationsModule",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileSystemAssets",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.EnvironmentsCompare",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogPublishing",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
+          "Version": "4.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Contracts",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.LuceneSearch",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureBlobAssets",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Content",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Sitemaps",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Return",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.ApplicationInsights",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.AuthorizeNetPayment",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCatalog",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.WhiteLabeling",
+          "Version": "3.909.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "Version": "3.1000.0"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tests_e2e/components/__init__.py
+++ b/tests_e2e/components/__init__.py
@@ -14,7 +14,9 @@ from .filter_slider_component import FilterSliderComponent
 from .language_selector_component import LanguageSelectorComponent
 from .line_item_component import LineItemComponent
 from .order_summary_component import OrderSummaryComponent
+from .pickup_location_card_dialog_component import PickupLocationCardDialogComponent
 from .pickup_location_list_item_component import PickupLocationListItemComponent
+from .pickup_locations_modal_component import PickupLocationsModalComponent
 from .product_card_component import ProductCardComponent
 from .quantity_stepper_component import QuantityStepperComponent
 from .search_bar_component import SearchBarComponent
@@ -50,7 +52,9 @@ __all__ = [
     "AddressFormComponent",
     "FilterSliderComponent",
     "FilterFacetComponent",
+    "PickupLocationCardDialogComponent",
     "PickupLocationListItemComponent",
+    "PickupLocationsModalComponent",
     "SelectBopisMapModalComponent",
     "FilterDropdownComponent",
     "ChipComponent",

--- a/tests_e2e/components/pickup_location_card_dialog_component.py
+++ b/tests_e2e/components/pickup_location_card_dialog_component.py
@@ -1,0 +1,26 @@
+from playwright.sync_api import Locator
+
+
+class PickupLocationCardDialogComponent:
+    def __init__(self, element: Locator):
+        self.element = element
+
+    @property
+    def name(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-card-name']")
+
+    @property
+    def info(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-card-info']")
+
+    @property
+    def cancel_button(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-card-cancel']")
+
+    @property
+    def select_button(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-card-select']")
+
+    @property
+    def close_button(self) -> Locator:
+        return self.element.locator("button[aria-label='Close']")

--- a/tests_e2e/components/pickup_locations_modal_component.py
+++ b/tests_e2e/components/pickup_locations_modal_component.py
@@ -84,22 +84,27 @@ class PickupLocationsModalComponent:
         return self.pickup_availability_chips.nth(index)
 
     def search(self, keyword: str) -> None:
-        """Fill the search input and submit with Enter key."""
         self.search_keyword_input.fill(keyword)
         self.search_keyword_input.press("Enter")
 
+    def wait_for_search_results(self, timeout: int = 10_000) -> None:
+
+        first_item = self.pickup_location_items.first
+        not_found = self.pickup_locations_not_found
+
+        # Use Playwright's built-in `or_` combinator to wait for either state.
+        first_item.or_(not_found).wait_for(state="visible", timeout=timeout)
+
     def click_location_by_index(self, index: int) -> None:
-        """Click a pickup location by its index to select it and show its card."""
 
         self.pickup_location_items.nth(index).locator(".vc-radio-button").click()
 
     def clear_search(self) -> None:
-        """Clear the search input and submit to reset results."""
         self.search_keyword_input.clear()
         self.search_keyword_input.press("Enter")
 
     def wait_for_map_ready(self, timeout: int = 15_000) -> None:
-        """Wait for the Google Map to be visible and at least one marker to be attached."""
+
         self.pickup_locations_map.wait_for(state="visible", timeout=timeout)
         markers = self.pickup_locations_map.locator("gmp-advanced-marker")
         if markers.count() > 0:

--- a/tests_e2e/components/pickup_locations_modal_component.py
+++ b/tests_e2e/components/pickup_locations_modal_component.py
@@ -1,0 +1,99 @@
+from playwright.sync_api import Locator, Page
+
+from .pickup_location_card_dialog_component import PickupLocationCardDialogComponent
+
+
+class PickupLocationsModalComponent:
+    """Component for the product page pickup locations modal dialog.
+
+    This modal is opened via the "Check pickup locations" button on the product page.
+    It contains a search box, a list of pickup locations, and a Google Map.
+    """
+
+    def __init__(self, element: Locator, page: Page):
+        self.element = element
+        self.page = page
+
+    @property
+    def search_keyword_input(self) -> Locator:
+        return self.element.locator("[data-test-id='search-keyword-input']")
+
+    @property
+    def search_button(self) -> Locator:
+        return self.element.locator("[data-test-id='search-button']")
+
+    @property
+    def pickup_locations_list(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-locations-list']")
+
+    @property
+    def pickup_location_items(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-item']")
+
+    @property
+    def pickup_location_names(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-name']")
+
+    @property
+    def pickup_location_addresses(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-location-address']")
+
+    @property
+    def pickup_availability_chips(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-availability-chip']")
+
+    @property
+    def pickup_locations_map(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-locations-map']")
+
+    @property
+    def select_address_map_desktop(self) -> Locator:
+        return self.element.locator("[data-test-id='select-address-map-desktop']")
+
+    @property
+    def pickup_locations_not_found(self) -> Locator:
+        return self.element.locator("[data-test-id='pickup-locations-not-found']")
+
+    @property
+    def reset_search_button(self) -> Locator:
+        return self.element.locator("[data-test-id='reset-search-button']")
+
+    @property
+    def close_button(self) -> Locator:
+        return self.element.locator("button[aria-label='Close']")
+
+    @property
+    def pickup_location_card(self) -> PickupLocationCardDialogComponent:
+        # Card dialog is rendered as a portal outside the modal DOM, so self.page is required here
+        return PickupLocationCardDialogComponent(self.page.locator("[data-test-id='pickup-location-card']"))
+
+    def get_location_item_by_index(self, index: int) -> Locator:
+        """Get a specific pickup location list item by its zero-based index."""
+        return self.pickup_location_items.nth(index)
+
+    def get_location_name_by_index(self, index: int) -> Locator:
+        """Get the name element of a specific pickup location by its zero-based index."""
+        return self.pickup_location_names.nth(index)
+
+    def get_location_address_by_index(self, index: int) -> Locator:
+        """Get the address element of a specific pickup location by its zero-based index."""
+        return self.pickup_location_addresses.nth(index)
+
+    def get_availability_chip_by_index(self, index: int) -> Locator:
+        """Get the availability chip of a specific pickup location by its zero-based index."""
+        return self.pickup_availability_chips.nth(index)
+
+    def search(self, keyword: str) -> None:
+        """Fill the search input and submit with Enter key."""
+        self.search_keyword_input.fill(keyword)
+        self.search_keyword_input.press("Enter")
+
+    def click_location_by_index(self, index: int) -> None:
+        """Click a pickup location by its index to select it and show its card."""
+        # Uses CSS class because vc-radio-button is a third-party component without a data-test-id
+        self.pickup_location_items.nth(index).locator(".vc-radio-button").click()
+
+    def clear_search(self) -> None:
+        """Clear the search input and submit to reset results."""
+        self.search_keyword_input.clear()
+        self.search_keyword_input.press("Enter")

--- a/tests_e2e/components/pickup_locations_modal_component.py
+++ b/tests_e2e/components/pickup_locations_modal_component.py
@@ -64,7 +64,7 @@ class PickupLocationsModalComponent:
 
     @property
     def pickup_location_card(self) -> PickupLocationCardDialogComponent:
-        # Card dialog is rendered as a portal outside the modal DOM, so self.page is required here
+
         return PickupLocationCardDialogComponent(self.page.locator("[data-test-id='pickup-location-card']"))
 
     def get_location_item_by_index(self, index: int) -> Locator:
@@ -90,10 +90,19 @@ class PickupLocationsModalComponent:
 
     def click_location_by_index(self, index: int) -> None:
         """Click a pickup location by its index to select it and show its card."""
-        # Uses CSS class because vc-radio-button is a third-party component without a data-test-id
+
         self.pickup_location_items.nth(index).locator(".vc-radio-button").click()
 
     def clear_search(self) -> None:
         """Clear the search input and submit to reset results."""
         self.search_keyword_input.clear()
         self.search_keyword_input.press("Enter")
+
+    def wait_for_map_ready(self, timeout: int = 15_000) -> None:
+        """Wait for the Google Map to be visible and at least one marker to be attached."""
+        self.pickup_locations_map.wait_for(state="visible", timeout=timeout)
+        markers = self.pickup_locations_map.locator("gmp-advanced-marker")
+        if markers.count() > 0:
+            markers.first.wait_for(state="attached", timeout=timeout)
+        else:
+            self.pickup_locations_map.locator("button[aria-label]").first.wait_for(state="attached", timeout=timeout)

--- a/tests_e2e/helpers.py
+++ b/tests_e2e/helpers.py
@@ -1,6 +1,19 @@
 from typing import Any
 
 import pytest
+from playwright.sync_api import Page
+
+from fixtures import Config
+from tests_e2e.pages import ProductPage
+
+
+def navigate_to_product_page(page: Page, config: Config, dataset: dict[str, Any], product_id: str) -> ProductPage:
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+    product = next(p for p in dataset["products"] if p["id"] == product_id)
+    pp = ProductPage(page, config, build_seo_path(product, dataset))
+    pp.navigate()
+    return pp
 
 
 def build_seo_path(product: dict, dataset: dict) -> str:

--- a/tests_e2e/helpers.py
+++ b/tests_e2e/helpers.py
@@ -30,7 +30,7 @@ def resolve_search_keyword(items: list[dict[str, Any]], case_id: str) -> str:
         return items[0]["name"]
 
     if case_id == "partial_name":
-        return items[0]["name"].split()[0]
+        return items[1]["name"].split()[0]
 
     if case_id in _ADDRESS_FIELD_MAP:
         field = _ADDRESS_FIELD_MAP[case_id]

--- a/tests_e2e/helpers.py
+++ b/tests_e2e/helpers.py
@@ -1,0 +1,12 @@
+def build_seo_path(product: dict, dataset: dict) -> str:
+    """Build full SEO path from category hierarchy + product semantic URL."""
+    categories_by_id = {c["id"]: c for c in dataset["categories"]}
+    parts = []
+    category_id = product["categoryId"]
+    while category_id:
+        cat = categories_by_id[category_id]
+        parts.append(cat["seoInfos"][0]["semanticUrl"])
+        category_id = cat.get("parentId")
+    parts.reverse()
+    parts.append(product["seoInfos"][0]["semanticUrl"])
+    return "/".join(parts)

--- a/tests_e2e/helpers.py
+++ b/tests_e2e/helpers.py
@@ -1,3 +1,8 @@
+from typing import Any
+
+import pytest
+
+
 def build_seo_path(product: dict, dataset: dict) -> str:
     """Build full SEO path from category hierarchy + product semantic URL."""
     categories_by_id = {c["id"]: c for c in dataset["categories"]}
@@ -10,3 +15,38 @@ def build_seo_path(product: dict, dataset: dict) -> str:
     parts.reverse()
     parts.append(product["seoInfos"][0]["semanticUrl"])
     return "/".join(parts)
+
+
+_ADDRESS_FIELD_MAP = {
+    "city": "city",
+    "street": "line1",
+    "postal_code": "postalCode",
+}
+
+
+def resolve_search_keyword(items: list[dict[str, Any]], case_id: str) -> str:
+    """Extract a search keyword from GraphQL location data for the given test case."""
+    if case_id == "full_name":
+        return items[0]["name"]
+
+    if case_id == "partial_name":
+        return items[0]["name"].split()[0]
+
+    if case_id in _ADDRESS_FIELD_MAP:
+        field = _ADDRESS_FIELD_MAP[case_id]
+        for loc in items:
+            value = (loc.get("address") or {}).get(field)
+            if value:
+                return value
+        pytest.skip(f"No location with '{case_id}' found in GraphQL data")
+
+    if case_id == "special_char":
+        for loc in items:
+            if any(ch in loc["name"] for ch in "-'.&()"):
+                return loc["name"]
+        pytest.skip("No location with special characters found in GraphQL data")
+
+    if case_id == "whitespace":
+        return f"  {items[0]['name']}  "
+
+    pytest.fail(f"Unknown search case: {case_id}")

--- a/tests_e2e/pages/product_page.py
+++ b/tests_e2e/pages/product_page.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Locator, Page
 
 from fixtures import Config
+from tests_e2e.components.pickup_locations_modal_component import PickupLocationsModalComponent
 from tests_e2e.components.variation_selector_component import VariationSelectorComponent
 
 from .main_layout_page import MainLayoutPage
@@ -69,6 +70,18 @@ class ProductPage(MainLayoutPage):
     def disabled_add_to_cart_button(self) -> Locator:
         return self.sidebar.locator("button.product-price__disabled-button")
 
+    @property
+    def shipment_options_widget(self) -> Locator:
+        return self.page.locator("[data-test-id='shipment-options-widget']")
+
+    @property
+    def check_pickup_locations_button(self) -> Locator:
+        return self.page.locator("[data-test-id='check-pickup-locations-button']")
+
+    @property
+    def pickup_locations_modal(self) -> PickupLocationsModalComponent:
+        return PickupLocationsModalComponent(self.page.locator("[data-test-id='pickup-locations-modal']"), self.page)
+
     def navigate(self) -> None:
         self.page.goto(self.url)
         self.page.wait_for_load_state("networkidle")
@@ -83,3 +96,10 @@ class ProductPage(MainLayoutPage):
 
     def is_variation_selector_visible(self) -> bool:
         return self.variation_selector_element.is_visible()
+
+    def open_pickup_locations_modal(self) -> PickupLocationsModalComponent:
+        """Click the 'Check pickup locations' button and return the modal component."""
+        self.check_pickup_locations_button.click()
+        modal = self.pickup_locations_modal
+        modal.element.wait_for(state="visible", timeout=10_000)
+        return modal

--- a/tests_e2e/tests/test_e2e_product_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_product_pickup_locations.py
@@ -1,0 +1,388 @@
+"""
+E2E tests for the pickup locations modal on the product page.
+
+Test Cases:
+- test_e2e_product_pickup_locations_modal_elements: Verify modal opens and all key UI elements are displayed
+- test_e2e_product_pickup_locations_list_content: Verify locations list contains items with name, address, and availability
+- test_e2e_product_pickup_locations_search_found: Search for a keyword that returns results
+- test_e2e_product_pickup_locations_search_not_found: Search for a keyword that returns no results
+- test_e2e_product_pickup_locations_reset_search: Search, then reset and verify full list is restored
+- test_e2e_product_pickup_locations_reset_search_button: Search non-existent keyword, click Reset search button to restore list
+- test_e2e_product_pickup_locations_select_location: Click a location to open the card dialog and verify content
+- test_e2e_product_pickup_locations_close_modal: Close the modal using the close button
+"""
+
+import os
+from typing import Any
+
+import allure
+import pytest
+from playwright.sync_api import Page, expect
+
+from fixtures import Config
+from tests_e2e.helpers import build_seo_path
+from tests_e2e.pages import ProductPage
+
+PRODUCT_ID = "product-acme-laptop-asus-vivobook-16-x1607qa"
+SEARCH_KEYWORD = "Union Square Greenmarket"
+
+
+@pytest.fixture
+def product_page(page: Page, config: Config, dataset: dict[str, Any]) -> ProductPage:
+    """Navigate to the pickup locations test product page."""
+    page.set_viewport_size({"width": 1920, "height": 1080})
+    product = next(p for p in dataset["products"] if p["id"] == PRODUCT_ID)
+    pp = ProductPage(page, config, build_seo_path(product, dataset))
+    pp.navigate()
+    return pp
+
+
+@pytest.mark.e2e
+@allure.title("Verify pickup locations modal elements on product page (E2E)")
+def test_e2e_product_pickup_locations_modal_elements(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to verify pickup locations modal elements on product page...",
+        end=" ",
+    )
+
+    expect(
+        product_page.shipment_options_widget,
+        "Shipment options widget should be visible on product page",
+    ).to_be_visible()
+
+    expect(
+        product_page.check_pickup_locations_button,
+        "Check pickup locations button should be visible on product page",
+    ).to_be_visible()
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
+    expect(modal.search_keyword_input, "Search input should be visible in modal").to_be_visible()
+    expect(modal.search_button, "Search button should be visible in modal").to_be_visible()
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible in modal").to_be_visible()
+    expect(modal.pickup_locations_map, "Google Map should be visible in modal").to_be_visible()
+    expect(modal.select_address_map_desktop, "Desktop layout container should be visible in modal").to_be_visible()
+    expect(modal.close_button, "Close button should be visible in modal").to_be_visible()
+
+    assert modal.pickup_location_items.count() > 0, "At least one pickup location item should be displayed"
+
+
+@pytest.mark.e2e
+@allure.title("Verify pickup locations list content on product page (E2E)")
+def test_e2e_product_pickup_locations_list_content(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to verify pickup locations list content on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    total_locations_count = modal.pickup_location_items.count()
+    assert total_locations_count > 0, f"Expected at least one pickup location, got {total_locations_count}"
+
+    first_name = modal.get_location_name_by_index(0)
+    first_address = modal.get_location_address_by_index(0)
+    first_chip = modal.get_availability_chip_by_index(0)
+
+    expect(first_name, "First location name should be visible").to_be_visible()
+    expect(first_address, "First location address should be visible").to_be_visible()
+    expect(first_chip, "First location availability chip should be visible").to_be_visible()
+
+    first_name_text = first_name.text_content()
+    first_address_text = first_address.text_content()
+    first_chip_text = first_chip.text_content()
+
+    assert first_name_text and len(first_name_text.strip()) > 0, "First location name should not be empty"
+    assert first_address_text and len(first_address_text.strip()) > 0, "First location address should not be empty"
+    assert first_chip_text and first_chip_text.strip() in (
+        "Today",
+        "Via transfer",
+    ), f"Availability chip should be 'Today' or 'Via transfer', got '{first_chip_text}'"
+
+    names_count = modal.pickup_location_names.count()
+    addresses_count = modal.pickup_location_addresses.count()
+    chips_count = modal.pickup_availability_chips.count()
+
+    assert (
+        names_count == total_locations_count
+    ), f"All locations should have names, expected {total_locations_count}, got {names_count}"
+    assert (
+        addresses_count == total_locations_count
+    ), f"All locations should have addresses, expected {total_locations_count}, got {addresses_count}"
+    assert (
+        chips_count == total_locations_count
+    ), f"All locations should have availability chips, expected {total_locations_count}, got {chips_count}"
+
+
+@pytest.mark.e2e
+@allure.title("Search pickup locations with matching keyword on product page (E2E)")
+def test_e2e_product_pickup_locations_search_found(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to search pickup locations with matching keyword on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    initial_count = modal.pickup_location_items.count()
+
+    keyword_to_search = SEARCH_KEYWORD
+
+    modal.search(keyword_to_search)
+
+    expect(modal.pickup_location_items.first, "At least one filtered result should be visible").to_be_visible()
+    expect(
+        modal.pickup_location_items,
+        f"Filtered results should be fewer than total ({initial_count})",
+    ).not_to_have_count(initial_count, timeout=10_000)
+
+    filtered_count = modal.pickup_location_items.count()
+    assert filtered_count >= 1, f"At least one location should match the keyword '{keyword_to_search}'"
+    assert (
+        filtered_count < initial_count
+    ), f"Filtered results ({filtered_count}) should be fewer than total ({initial_count})"
+
+    expect(
+        modal.pickup_locations_not_found,
+        "Not found message should not be visible when results exist",
+    ).not_to_be_visible()
+
+    for i in range(filtered_count):
+        name_text = modal.get_location_name_by_index(i).text_content() or ""
+        address_text = modal.get_location_address_by_index(i).text_content() or ""
+        combined_text = f"{name_text} {address_text}".lower()
+        assert keyword_to_search.lower() in combined_text, (
+            f"Location at index {i} (name='{name_text}', address='{address_text}') "
+            f"does not contain keyword '{keyword_to_search}'"
+        )
+
+
+@pytest.mark.e2e
+@allure.title("Search pickup locations with non-matching keyword on product page (E2E)")
+def test_e2e_product_pickup_locations_search_not_found(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to search pickup locations with non-matching keyword on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    keyword_to_search = "NonExistentLocationXYZ123"
+
+    modal.search(keyword_to_search)
+
+    expect(
+        modal.pickup_locations_not_found,
+        "Not found message should be visible when no locations match the search",
+    ).to_be_visible()
+
+    assert (
+        modal.pickup_location_items.count() == 0
+    ), f"No pickup locations should be displayed for keyword '{keyword_to_search}'"
+
+
+@pytest.mark.e2e
+@allure.title("Reset search and restore full pickup locations list on product page (E2E)")
+def test_e2e_product_pickup_locations_reset_search(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to reset search and restore pickup locations list on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    initial_count = modal.pickup_location_items.count()
+    assert initial_count > 0, f"Expected at least one pickup location initially, got {initial_count}"
+
+    # Search to filter the list
+    keyword_to_search = SEARCH_KEYWORD
+    modal.search(keyword_to_search)
+
+    # Wait for the list to actually filter
+    expect(
+        modal.pickup_location_items,
+        f"Filtered results should be fewer than total ({initial_count})",
+    ).not_to_have_count(initial_count, timeout=10_000)
+
+    filtered_count = modal.pickup_location_items.count()
+    assert (
+        filtered_count < initial_count
+    ), f"Filtered count ({filtered_count}) should be less than initial count ({initial_count})"
+
+    # Reset the search by clearing input and pressing Enter
+    modal.clear_search()
+
+    # Wait for the full list to be restored
+    expect(modal.pickup_location_items.first, "First location item should be visible after reset").to_be_visible()
+    expect(
+        modal.pickup_location_items,
+        f"Full list should be restored to {initial_count} items",
+    ).to_have_count(initial_count, timeout=10_000)
+
+    restored_count = modal.pickup_location_items.count()
+    assert (
+        restored_count == initial_count
+    ), f"After reset, expected {initial_count} pickup locations, got {restored_count}"
+
+    # Verify the search input is cleared
+    expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
+
+
+@pytest.mark.e2e
+@allure.title("Reset search via reset button and restore full pickup locations list on product page (E2E)")
+def test_e2e_product_pickup_locations_reset_search_button(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to reset search via reset button on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    initial_count = modal.pickup_location_items.count()
+    assert initial_count > 0, f"Expected at least one pickup location initially, got {initial_count}"
+
+    # Search for a non-existent keyword to trigger "not found" state
+    keyword_to_search = "NonExistentLocationXYZ123"
+    modal.search(keyword_to_search)
+
+    # Verify "not found" message and reset button are visible
+    expect(
+        modal.pickup_locations_not_found,
+        "Not found message should be visible when no locations match the search",
+    ).to_be_visible()
+    assert modal.pickup_location_items.count() == 0, "No pickup locations should be displayed"
+
+    expect(
+        modal.reset_search_button,
+        "Reset search button should be visible when no results found",
+    ).to_be_visible()
+
+    modal.reset_search_button.click()
+
+    expect(modal.pickup_location_items.first, "First location item should be visible after reset").to_be_visible()
+    expect(
+        modal.pickup_location_items,
+        f"Full list should be restored to {initial_count} items",
+    ).to_have_count(initial_count, timeout=10_000)
+
+    restored_count = modal.pickup_location_items.count()
+    assert (
+        restored_count == initial_count
+    ), f"After reset, expected {initial_count} pickup locations, got {restored_count}"
+
+    expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
+
+    expect(
+        modal.pickup_locations_not_found,
+        "Not found message should not be visible after reset",
+    ).not_to_be_visible()
+    expect(
+        modal.reset_search_button,
+        "Reset search button should not be visible after reset",
+    ).not_to_be_visible()
+
+
+@pytest.mark.e2e
+@allure.title("Select a pickup location and verify card dialog on product page (E2E)")
+def test_e2e_product_pickup_locations_select_location(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to select a pickup location and verify card dialog on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+
+    map_locator = modal.pickup_locations_map
+    markers = map_locator.locator("gmp-advanced-marker")
+    if markers.count() > 0:
+        markers.first.wait_for(state="attached", timeout=15_000)
+    else:
+        map_locator.locator("button[aria-label]").first.wait_for(state="attached", timeout=15_000)
+
+    total_count = modal.pickup_location_items.count()
+    assert total_count >= 2, f"Expected at least 2 pickup locations, got {total_count}"
+
+    # Select multiple locations: first, second, and last
+    indices_to_test = [0, 1, total_count - 1]
+    card = modal.pickup_location_card
+
+    for index in indices_to_test:
+        location_name_text = modal.get_location_name_by_index(index).text_content()
+        modal.click_location_by_index(index)
+
+        expect(card.element, f"Card should be visible after clicking location at index {index}").to_be_visible()
+        expect(card.name, f"Card name should be visible for location at index {index}").to_be_visible()
+        expect(card.info, f"Card info should be visible for location at index {index}").to_be_visible()
+
+        card_name_text = card.name.text_content()
+        assert (
+            card_name_text == location_name_text
+        ), f"Card name '{card_name_text}' should match clicked location name '{location_name_text}' at index {index}"
+
+        card.close_button.click()
+
+        expect(card.element, f"Card should be hidden after closing for location at index {index}").not_to_be_visible()
+
+    expect(modal.element, "Pickup locations modal should still be visible after closing card dialog").to_be_visible()
+
+
+@pytest.mark.e2e
+@allure.title("Close pickup locations modal using close button on product page (E2E)")
+def test_e2e_product_pickup_locations_close_modal(
+    page: Page,
+    product_page: ProductPage,
+):
+    print(
+        f"{os.linesep}Running E2E test to close pickup locations modal on product page...",
+        end=" ",
+    )
+
+    modal = product_page.open_pickup_locations_modal()
+
+    expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
+
+    modal.close_button.click()
+
+    expect(
+        modal.element,
+        "Pickup locations modal should not be visible after clicking close",
+    ).not_to_be_visible()
+
+    expect(
+        product_page.check_pickup_locations_button,
+        "Check pickup locations button should still be visible after closing modal",
+    ).to_be_visible()

--- a/tests_e2e/tests/test_e2e_product_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_product_pickup_locations.py
@@ -259,7 +259,7 @@ def test_e2e_product_pickup_locations_search_reset(
     )
 
     expected_total = pickup_locations_data["totalCount"]
-    keyword_to_search = pickup_locations_data["items"][0]["name"]
+    keyword_to_search = pickup_locations_data["items"][2]["name"]
 
     modal = product_page.open_pickup_locations_modal()
     modal.wait_for_map_ready()

--- a/tests_e2e/tests/test_e2e_product_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_product_pickup_locations.py
@@ -4,7 +4,13 @@ E2E tests for the pickup locations modal on the product page.
 Test Cases:
 - test_e2e_product_pickup_locations_modal_elements: Verify modal opens and all key UI elements are displayed
 - test_e2e_product_pickup_locations_list_content: Verify locations list contains items with name, address, and availability
-- test_e2e_product_pickup_locations_search_found: Search for a keyword that returns results
+- test_e2e_product_pickup_locations_search_found[full_name]: Search by exact full location name
+- test_e2e_product_pickup_locations_search_found[partial_name]: Search by first word of a location name
+- test_e2e_product_pickup_locations_search_found[city]: Search by city name (skipped — known frontend bug)
+- test_e2e_product_pickup_locations_search_found[street]: Search by street address (skipped — known frontend bug)
+- test_e2e_product_pickup_locations_search_found[postal_code]: Search by postal code (skipped — known frontend bug)
+- test_e2e_product_pickup_locations_search_found[special_char]: Search by name containing special characters
+- test_e2e_product_pickup_locations_search_found[whitespace]: Search with leading/trailing whitespace (skipped — UI does not trim)
 - test_e2e_product_pickup_locations_search_not_found: Search for a keyword that returns no results
 - test_e2e_product_pickup_locations_reset_search: Search, then reset and verify full list is restored
 - test_e2e_product_pickup_locations_reset_search_button: Search non-existent keyword, click Reset search button to restore list
@@ -19,12 +25,38 @@ import allure
 import pytest
 from playwright.sync_api import Page, expect
 
-from fixtures import Config
+from fixtures import Config, GraphQLClient
+from graphql_operations.pickup_locations.pickup_locations_operations import (
+    PickupLocationsOperations,
+)
 from tests_e2e.helpers import build_seo_path
 from tests_e2e.pages import ProductPage
 
 PRODUCT_ID = "product-acme-laptop-asus-vivobook-16-x1607qa"
-SEARCH_KEYWORD = "Union Square Greenmarket"
+NON_EXISTENT_KEYWORD = "NonExistentLocationXYZ123"
+
+
+@pytest.fixture
+def pickup_locations_data(graphql_client: GraphQLClient, config: Config, dataset: dict[str, Any]) -> dict[str, Any]:
+    """Fetch product pickup locations via GraphQL to use as expected data in E2E tests."""
+    operations = PickupLocationsOperations(graphql_client)
+    culture = dataset["languages"][0]["allowedValues"][0]
+    initial = operations.get_product_pickup_locations(
+        product_id=PRODUCT_ID,
+        store_id=config["STORE_ID"],
+        culture_name=culture,
+        first=50,
+    )
+    total = initial["totalCount"]
+    assert total > 0, f"No pickup locations found for product {PRODUCT_ID} via GraphQL"
+
+    result = operations.get_product_pickup_locations(
+        product_id=PRODUCT_ID,
+        store_id=config["STORE_ID"],
+        culture_name=culture,
+        first=total,
+    )
+    return result
 
 
 @pytest.fixture
@@ -40,13 +72,15 @@ def product_page(page: Page, config: Config, dataset: dict[str, Any]) -> Product
 @pytest.mark.e2e
 @allure.title("Verify pickup locations modal elements on product page (E2E)")
 def test_e2e_product_pickup_locations_modal_elements(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
 ):
     print(
         f"{os.linesep}Running E2E test to verify pickup locations modal elements on product page...",
         end=" ",
     )
+
+    expected_count = pickup_locations_data["totalCount"]
 
     expect(
         product_page.shipment_options_widget,
@@ -59,35 +93,48 @@ def test_e2e_product_pickup_locations_modal_elements(
     ).to_be_visible()
 
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
     expect(modal.search_keyword_input, "Search input should be visible in modal").to_be_visible()
     expect(modal.search_button, "Search button should be visible in modal").to_be_visible()
     expect(modal.pickup_locations_list, "Pickup locations list should be visible in modal").to_be_visible()
     expect(modal.pickup_locations_map, "Google Map should be visible in modal").to_be_visible()
-    expect(modal.select_address_map_desktop, "Desktop layout container should be visible in modal").to_be_visible()
+    expect(
+        modal.select_address_map_desktop,
+        "Desktop layout container should be visible in modal",
+    ).to_be_visible()
     expect(modal.close_button, "Close button should be visible in modal").to_be_visible()
 
-    assert modal.pickup_location_items.count() > 0, "At least one pickup location item should be displayed"
+    expect(
+        modal.pickup_location_items,
+        f"Pickup locations count should match GraphQL ({expected_count})",
+    ).to_have_count(expected_count, timeout=10_000)
 
 
 @pytest.mark.e2e
 @allure.title("Verify pickup locations list content on product page (E2E)")
 def test_e2e_product_pickup_locations_list_content(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
 ):
     print(
         f"{os.linesep}Running E2E test to verify pickup locations list content on product page...",
         end=" ",
     )
 
+    expected_count = pickup_locations_data["totalCount"]
+    expected_names = {loc["name"] for loc in pickup_locations_data["items"]}
+
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    total_locations_count = modal.pickup_location_items.count()
-    assert total_locations_count > 0, f"Expected at least one pickup location, got {total_locations_count}"
+    expect(
+        modal.pickup_location_items,
+        f"Pickup locations count should match GraphQL ({expected_count})",
+    ).to_have_count(expected_count, timeout=10_000)
 
     first_name = modal.get_location_name_by_index(0)
     first_address = modal.get_location_address_by_index(0)
@@ -97,84 +144,153 @@ def test_e2e_product_pickup_locations_list_content(
     expect(first_address, "First location address should be visible").to_be_visible()
     expect(first_chip, "First location availability chip should be visible").to_be_visible()
 
-    first_name_text = first_name.text_content()
-    first_address_text = first_address.text_content()
-    first_chip_text = first_chip.text_content()
+    first_name_text = (first_name.text_content() or "").strip()
+    first_address_text = (first_address.text_content() or "").strip()
+    first_chip_text = (first_chip.text_content() or "").strip()
 
-    assert first_name_text and len(first_name_text.strip()) > 0, "First location name should not be empty"
-    assert first_address_text and len(first_address_text.strip()) > 0, "First location address should not be empty"
-    assert first_chip_text and first_chip_text.strip() in (
-        "Today",
-        "Via transfer",
-    ), f"Availability chip should be 'Today' or 'Via transfer', got '{first_chip_text}'"
+    assert first_name_text, "First location name should not be empty"
+    assert first_address_text, "First location address should not be empty"
+    assert first_chip_text, "First location availability chip should not be empty"
+
+    assert (
+        first_name_text in expected_names
+    ), f"First location name '{first_name_text}' should match one of the GraphQL names: {expected_names}"
 
     names_count = modal.pickup_location_names.count()
     addresses_count = modal.pickup_location_addresses.count()
     chips_count = modal.pickup_availability_chips.count()
 
     assert (
-        names_count == total_locations_count
-    ), f"All locations should have names, expected {total_locations_count}, got {names_count}"
+        names_count == expected_count
+    ), f"All locations should have names, expected {expected_count}, got {names_count}"
     assert (
-        addresses_count == total_locations_count
-    ), f"All locations should have addresses, expected {total_locations_count}, got {addresses_count}"
+        addresses_count == expected_count
+    ), f"All locations should have addresses, expected {expected_count}, got {addresses_count}"
     assert (
-        chips_count == total_locations_count
-    ), f"All locations should have availability chips, expected {total_locations_count}, got {chips_count}"
+        chips_count == expected_count
+    ), f"All locations should have availability chips, expected {expected_count}, got {chips_count}"
+
+
+_ADDRESS_FIELD_MAP = {
+    "city": "city",
+    "street": "line1",
+    "postal_code": "postalCode",
+}
+
+
+def _resolve_search_keyword(items: list[dict[str, Any]], case_id: str) -> str:
+    """Extract a search keyword from GraphQL location data for the given test case."""
+    if case_id == "full_name":
+        return items[0]["name"]
+
+    if case_id == "partial_name":
+        return items[0]["name"].split()[0]
+
+    if case_id in _ADDRESS_FIELD_MAP:
+        field = _ADDRESS_FIELD_MAP[case_id]
+        for loc in items:
+            value = (loc.get("address") or {}).get(field)
+            if value:
+                return value
+        pytest.skip(f"No location with '{case_id}' found in GraphQL data")
+
+    if case_id == "special_char":
+        for loc in items:
+            if any(ch in loc["name"] for ch in "-'.&()"):
+                return loc["name"]
+        pytest.skip("No location with special characters found in GraphQL data")
+
+    if case_id == "whitespace":
+        return f"  {items[0]['name']}  "
+
+    pytest.fail(f"Unknown search case: {case_id}")
+
+
+_ADDRESS_SEARCH_BUG_REASON = "Frontend search only matches by name, not by address fields (to be fixed by dev team)"
+_WHITESPACE_SEARCH_BUG_REASON = "Frontend search does not trim leading/trailing whitespace (to be fixed by dev team)"
+
+SEARCH_CASES = [
+    pytest.param("full_name", id="full_name"),
+    pytest.param("partial_name", id="partial_name"),
+    pytest.param("city", id="city", marks=pytest.mark.skip(reason=_ADDRESS_SEARCH_BUG_REASON)),
+    pytest.param(
+        "street",
+        id="street",
+        marks=pytest.mark.skip(reason=_ADDRESS_SEARCH_BUG_REASON),
+    ),
+    pytest.param(
+        "postal_code",
+        id="postal_code",
+        marks=pytest.mark.skip(reason=_ADDRESS_SEARCH_BUG_REASON),
+    ),
+    pytest.param("special_char", id="special_char"),
+    pytest.param(
+        "whitespace",
+        id="whitespace",
+        marks=pytest.mark.skip(reason=_WHITESPACE_SEARCH_BUG_REASON),
+    ),
+]
 
 
 @pytest.mark.e2e
-@allure.title("Search pickup locations with matching keyword on product page (E2E)")
+@pytest.mark.parametrize("search_case_id", SEARCH_CASES)
+@allure.title("Search pickup locations on product page (E2E)")
 def test_e2e_product_pickup_locations_search_found(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
+    search_case_id: str,
 ):
+    items = pickup_locations_data["items"]
+    keyword_to_search = _resolve_search_keyword(items, search_case_id)
+    keyword_display = keyword_to_search.strip().encode("ascii", "replace").decode()
+    allure.dynamic.title(f"Search pickup locations by {search_case_id}: '{keyword_to_search.strip()}' (E2E)")
+
     print(
-        f"{os.linesep}Running E2E test to search pickup locations with matching keyword on product page...",
+        f"{os.linesep}Running E2E search test [{search_case_id}] keyword='{keyword_display}'...",
         end=" ",
     )
 
+    expected_total = pickup_locations_data["totalCount"]
+
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    initial_count = modal.pickup_location_items.count()
-
-    keyword_to_search = SEARCH_KEYWORD
+    expect(
+        modal.pickup_location_items,
+        f"Initial count should match GraphQL ({expected_total})",
+    ).to_have_count(expected_total, timeout=10_000)
 
     modal.search(keyword_to_search)
 
-    expect(modal.pickup_location_items.first, "At least one filtered result should be visible").to_be_visible()
     expect(
         modal.pickup_location_items,
-        f"Filtered results should be fewer than total ({initial_count})",
-    ).not_to_have_count(initial_count, timeout=10_000)
-
-    filtered_count = modal.pickup_location_items.count()
-    assert filtered_count >= 1, f"At least one location should match the keyword '{keyword_to_search}'"
-    assert (
-        filtered_count < initial_count
-    ), f"Filtered results ({filtered_count}) should be fewer than total ({initial_count})"
+        "Search should filter results (count should decrease from initial total)",
+    ).not_to_have_count(expected_total, timeout=10_000)
 
     expect(
         modal.pickup_locations_not_found,
         "Not found message should not be visible when results exist",
     ).not_to_be_visible()
 
+    filtered_count = modal.pickup_location_items.count()
+    assert filtered_count > 0, f"At least one location should match keyword '{keyword_to_search.strip()}'"
+
+    keyword_normalized = keyword_to_search.strip().lower()
     for i in range(filtered_count):
         name_text = modal.get_location_name_by_index(i).text_content() or ""
         address_text = modal.get_location_address_by_index(i).text_content() or ""
         combined_text = f"{name_text} {address_text}".lower()
-        assert keyword_to_search.lower() in combined_text, (
-            f"Location at index {i} (name='{name_text}', address='{address_text}') "
-            f"does not contain keyword '{keyword_to_search}'"
+        assert keyword_normalized in combined_text, (
+            f"[{search_case_id}] Location at index {i} (name='{name_text}', "
+            f"address='{address_text}') does not contain keyword '{keyword_to_search.strip()}'"
         )
 
 
 @pytest.mark.e2e
 @allure.title("Search pickup locations with non-matching keyword on product page (E2E)")
 def test_e2e_product_pickup_locations_search_not_found(
-    page: Page,
     product_page: ProductPage,
 ):
     print(
@@ -183,10 +299,11 @@ def test_e2e_product_pickup_locations_search_not_found(
     )
 
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    keyword_to_search = "NonExistentLocationXYZ123"
+    keyword_to_search = NON_EXISTENT_KEYWORD
 
     modal.search(keyword_to_search)
 
@@ -203,78 +320,74 @@ def test_e2e_product_pickup_locations_search_not_found(
 @pytest.mark.e2e
 @allure.title("Reset search and restore full pickup locations list on product page (E2E)")
 def test_e2e_product_pickup_locations_reset_search(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
 ):
     print(
         f"{os.linesep}Running E2E test to reset search and restore pickup locations list on product page...",
         end=" ",
     )
 
+    expected_total = pickup_locations_data["totalCount"]
+    keyword_to_search = pickup_locations_data["items"][0]["name"]
+
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    initial_count = modal.pickup_location_items.count()
-    assert initial_count > 0, f"Expected at least one pickup location initially, got {initial_count}"
+    expect(
+        modal.pickup_location_items,
+        f"Initial count should match GraphQL ({expected_total})",
+    ).to_have_count(expected_total, timeout=10_000)
 
-    # Search to filter the list
-    keyword_to_search = SEARCH_KEYWORD
     modal.search(keyword_to_search)
 
-    # Wait for the list to actually filter
     expect(
-        modal.pickup_location_items,
-        f"Filtered results should be fewer than total ({initial_count})",
-    ).not_to_have_count(initial_count, timeout=10_000)
+        modal.pickup_location_items.first,
+        "At least one filtered result should be visible",
+    ).to_be_visible()
 
-    filtered_count = modal.pickup_location_items.count()
-    assert (
-        filtered_count < initial_count
-    ), f"Filtered count ({filtered_count}) should be less than initial count ({initial_count})"
-
-    # Reset the search by clearing input and pressing Enter
     modal.clear_search()
 
-    # Wait for the full list to be restored
-    expect(modal.pickup_location_items.first, "First location item should be visible after reset").to_be_visible()
+    expect(
+        modal.pickup_location_items.first,
+        "First location item should be visible after reset",
+    ).to_be_visible()
     expect(
         modal.pickup_location_items,
-        f"Full list should be restored to {initial_count} items",
-    ).to_have_count(initial_count, timeout=10_000)
+        f"Full list should be restored to {expected_total} items",
+    ).to_have_count(expected_total, timeout=10_000)
 
-    restored_count = modal.pickup_location_items.count()
-    assert (
-        restored_count == initial_count
-    ), f"After reset, expected {initial_count} pickup locations, got {restored_count}"
-
-    # Verify the search input is cleared
     expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
 
 
 @pytest.mark.e2e
 @allure.title("Reset search via reset button and restore full pickup locations list on product page (E2E)")
 def test_e2e_product_pickup_locations_reset_search_button(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
 ):
     print(
         f"{os.linesep}Running E2E test to reset search via reset button on product page...",
         end=" ",
     )
 
+    expected_total = pickup_locations_data["totalCount"]
+
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    initial_count = modal.pickup_location_items.count()
-    assert initial_count > 0, f"Expected at least one pickup location initially, got {initial_count}"
+    expect(
+        modal.pickup_location_items,
+        f"Initial count should match GraphQL ({expected_total})",
+    ).to_have_count(expected_total, timeout=10_000)
 
-    # Search for a non-existent keyword to trigger "not found" state
-    keyword_to_search = "NonExistentLocationXYZ123"
+    keyword_to_search = NON_EXISTENT_KEYWORD
     modal.search(keyword_to_search)
 
-    # Verify "not found" message and reset button are visible
     expect(
         modal.pickup_locations_not_found,
         "Not found message should be visible when no locations match the search",
@@ -288,16 +401,14 @@ def test_e2e_product_pickup_locations_reset_search_button(
 
     modal.reset_search_button.click()
 
-    expect(modal.pickup_location_items.first, "First location item should be visible after reset").to_be_visible()
+    expect(
+        modal.pickup_location_items.first,
+        "First location item should be visible after reset",
+    ).to_be_visible()
     expect(
         modal.pickup_location_items,
-        f"Full list should be restored to {initial_count} items",
-    ).to_have_count(initial_count, timeout=10_000)
-
-    restored_count = modal.pickup_location_items.count()
-    assert (
-        restored_count == initial_count
-    ), f"After reset, expected {initial_count} pickup locations, got {restored_count}"
+        f"Full list should be restored to {expected_total} items",
+    ).to_have_count(expected_total, timeout=10_000)
 
     expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
 
@@ -314,29 +425,30 @@ def test_e2e_product_pickup_locations_reset_search_button(
 @pytest.mark.e2e
 @allure.title("Select a pickup location and verify card dialog on product page (E2E)")
 def test_e2e_product_pickup_locations_select_location(
-    page: Page,
     product_page: ProductPage,
+    pickup_locations_data: dict[str, Any],
 ):
     print(
         f"{os.linesep}Running E2E test to select a pickup location and verify card dialog on product page...",
         end=" ",
     )
 
+    expected_total = pickup_locations_data["totalCount"]
+    expected_names = {loc["name"] for loc in pickup_locations_data["items"]}
+
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
 
-    map_locator = modal.pickup_locations_map
-    markers = map_locator.locator("gmp-advanced-marker")
-    if markers.count() > 0:
-        markers.first.wait_for(state="attached", timeout=15_000)
-    else:
-        map_locator.locator("button[aria-label]").first.wait_for(state="attached", timeout=15_000)
+    expect(
+        modal.pickup_location_items,
+        f"Pickup locations count should match GraphQL ({expected_total})",
+    ).to_have_count(expected_total, timeout=10_000)
 
     total_count = modal.pickup_location_items.count()
     assert total_count >= 2, f"Expected at least 2 pickup locations, got {total_count}"
 
-    # Select multiple locations: first, second, and last
     indices_to_test = [0, 1, total_count - 1]
     card = modal.pickup_location_card
 
@@ -344,7 +456,10 @@ def test_e2e_product_pickup_locations_select_location(
         location_name_text = modal.get_location_name_by_index(index).text_content()
         modal.click_location_by_index(index)
 
-        expect(card.element, f"Card should be visible after clicking location at index {index}").to_be_visible()
+        expect(
+            card.element,
+            f"Card should be visible after clicking location at index {index}",
+        ).to_be_visible()
         expect(card.name, f"Card name should be visible for location at index {index}").to_be_visible()
         expect(card.info, f"Card info should be visible for location at index {index}").to_be_visible()
 
@@ -353,17 +468,26 @@ def test_e2e_product_pickup_locations_select_location(
             card_name_text == location_name_text
         ), f"Card name '{card_name_text}' should match clicked location name '{location_name_text}' at index {index}"
 
+        assert (
+            card_name_text in expected_names
+        ), f"Card name '{card_name_text}' should be one of the GraphQL location names: {expected_names}"
+
         card.close_button.click()
 
-        expect(card.element, f"Card should be hidden after closing for location at index {index}").not_to_be_visible()
+        expect(
+            card.element,
+            f"Card should be hidden after closing for location at index {index}",
+        ).not_to_be_visible()
 
-    expect(modal.element, "Pickup locations modal should still be visible after closing card dialog").to_be_visible()
+    expect(
+        modal.element,
+        "Pickup locations modal should still be visible after closing card dialog",
+    ).to_be_visible()
 
 
 @pytest.mark.e2e
 @allure.title("Close pickup locations modal using close button on product page (E2E)")
 def test_e2e_product_pickup_locations_close_modal(
-    page: Page,
     product_page: ProductPage,
 ):
     print(
@@ -372,6 +496,7 @@ def test_e2e_product_pickup_locations_close_modal(
     )
 
     modal = product_page.open_pickup_locations_modal()
+    modal.wait_for_map_ready()
 
     expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
 

--- a/tests_e2e/tests/test_e2e_product_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_product_pickup_locations.py
@@ -26,7 +26,7 @@ from fixtures import Config, GraphQLClient
 from graphql_operations.pickup_locations.pickup_locations_operations import (
     PickupLocationsOperations,
 )
-from tests_e2e.helpers import build_seo_path, resolve_search_keyword
+from tests_e2e.helpers import build_seo_path, navigate_to_product_page, resolve_search_keyword
 from tests_e2e.pages import ProductPage
 
 PRODUCT_ID = "product-acme-laptop-asus-vivobook-16-x1607qa"
@@ -60,11 +60,7 @@ def pickup_locations_data(graphql_client: GraphQLClient, config: Config, dataset
 @pytest.fixture
 def product_page(page: Page, config: Config, dataset: dict[str, Any]) -> ProductPage:
     """Navigate to the pickup locations test product page."""
-    page.set_viewport_size({"width": 1920, "height": 1080})
-    product = next(p for p in dataset["products"] if p["id"] == PRODUCT_ID)
-    pp = ProductPage(page, config, build_seo_path(product, dataset))
-    pp.navigate()
-    return pp
+    return navigate_to_product_page(page, config, dataset, PRODUCT_ID)
 
 
 @pytest.mark.e2e
@@ -421,11 +417,7 @@ def test_e2e_product_out_of_stock_pickup_locations_not_displayed(
         end=" ",
     )
 
-    page.set_viewport_size({"width": 1920, "height": 1080})
-
-    product = next(p for p in dataset["products"] if p["id"] == OUT_OF_STOCK_PRODUCT_ID)
-    product_page = ProductPage(page, config, build_seo_path(product, dataset))
-    product_page.navigate()
+    product_page = navigate_to_product_page(page, config, dataset, OUT_OF_STOCK_PRODUCT_ID)
 
     with allure.step("Verify product page loaded"):
         expect(

--- a/tests_e2e/tests/test_e2e_product_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_product_pickup_locations.py
@@ -2,8 +2,7 @@
 E2E tests for the pickup locations modal on the product page.
 
 Test Cases:
-- test_e2e_product_pickup_locations_modal_elements: Verify modal opens and all key UI elements are displayed
-- test_e2e_product_pickup_locations_list_content: Verify locations list contains items with name, address, and availability
+- test_e2e_product_pickup_locations_modal_and_list: Verify modal UI elements and list content (name, address, availability)
 - test_e2e_product_pickup_locations_search_found[full_name]: Search by exact full location name
 - test_e2e_product_pickup_locations_search_found[partial_name]: Search by first word of a location name
 - test_e2e_product_pickup_locations_search_found[city]: Search by city name (skipped — known frontend bug)
@@ -11,11 +10,9 @@ Test Cases:
 - test_e2e_product_pickup_locations_search_found[postal_code]: Search by postal code (skipped — known frontend bug)
 - test_e2e_product_pickup_locations_search_found[special_char]: Search by name containing special characters
 - test_e2e_product_pickup_locations_search_found[whitespace]: Search with leading/trailing whitespace (skipped — UI does not trim)
-- test_e2e_product_pickup_locations_search_not_found: Search for a keyword that returns no results
-- test_e2e_product_pickup_locations_reset_search: Search, then reset and verify full list is restored
-- test_e2e_product_pickup_locations_reset_search_button: Search non-existent keyword, click Reset search button to restore list
-- test_e2e_product_pickup_locations_select_location: Click a location to open the card dialog and verify content
-- test_e2e_product_pickup_locations_close_modal: Close the modal using the close button
+- test_e2e_product_pickup_locations_search_reset: Search found → clear reset → search not found → reset button
+- test_e2e_product_pickup_locations_select_location: Click locations to verify card dialog, then close modal
+- test_e2e_product_out_of_stock_pickup_locations_not_displayed: Product out of stock — pickup locations widget is NOT displayed
 """
 
 import os
@@ -29,10 +26,11 @@ from fixtures import Config, GraphQLClient
 from graphql_operations.pickup_locations.pickup_locations_operations import (
     PickupLocationsOperations,
 )
-from tests_e2e.helpers import build_seo_path
+from tests_e2e.helpers import build_seo_path, resolve_search_keyword
 from tests_e2e.pages import ProductPage
 
 PRODUCT_ID = "product-acme-laptop-asus-vivobook-16-x1607qa"
+OUT_OF_STOCK_PRODUCT_ID = "product-acme-laptop-acer-aspire-16-ai"
 NON_EXISTENT_KEYWORD = "NonExistentLocationXYZ123"
 
 
@@ -70,140 +68,87 @@ def product_page(page: Page, config: Config, dataset: dict[str, Any]) -> Product
 
 
 @pytest.mark.e2e
-@allure.title("Verify pickup locations modal elements on product page (E2E)")
-def test_e2e_product_pickup_locations_modal_elements(
+@allure.title("Verify pickup locations modal and list content on product page (E2E)")
+def test_e2e_product_pickup_locations_modal_and_list(
     product_page: ProductPage,
     pickup_locations_data: dict[str, Any],
 ):
     print(
-        f"{os.linesep}Running E2E test to verify pickup locations modal elements on product page...",
-        end=" ",
-    )
-
-    expected_count = pickup_locations_data["totalCount"]
-
-    expect(
-        product_page.shipment_options_widget,
-        "Shipment options widget should be visible on product page",
-    ).to_be_visible()
-
-    expect(
-        product_page.check_pickup_locations_button,
-        "Check pickup locations button should be visible on product page",
-    ).to_be_visible()
-
-    modal = product_page.open_pickup_locations_modal()
-    modal.wait_for_map_ready()
-
-    expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
-    expect(modal.search_keyword_input, "Search input should be visible in modal").to_be_visible()
-    expect(modal.search_button, "Search button should be visible in modal").to_be_visible()
-    expect(modal.pickup_locations_list, "Pickup locations list should be visible in modal").to_be_visible()
-    expect(modal.pickup_locations_map, "Google Map should be visible in modal").to_be_visible()
-    expect(
-        modal.select_address_map_desktop,
-        "Desktop layout container should be visible in modal",
-    ).to_be_visible()
-    expect(modal.close_button, "Close button should be visible in modal").to_be_visible()
-
-    expect(
-        modal.pickup_location_items,
-        f"Pickup locations count should match GraphQL ({expected_count})",
-    ).to_have_count(expected_count, timeout=10_000)
-
-
-@pytest.mark.e2e
-@allure.title("Verify pickup locations list content on product page (E2E)")
-def test_e2e_product_pickup_locations_list_content(
-    product_page: ProductPage,
-    pickup_locations_data: dict[str, Any],
-):
-    print(
-        f"{os.linesep}Running E2E test to verify pickup locations list content on product page...",
+        f"{os.linesep}Running E2E test to verify pickup locations modal and list content on product page...",
         end=" ",
     )
 
     expected_count = pickup_locations_data["totalCount"]
     expected_names = {loc["name"] for loc in pickup_locations_data["items"]}
 
+    with allure.step("Verify product page elements"):
+        expect(
+            product_page.shipment_options_widget,
+            "Shipment options widget should be visible on product page",
+        ).to_be_visible()
+
+        expect(
+            product_page.check_pickup_locations_button,
+            "Check pickup locations button should be visible on product page",
+        ).to_be_visible()
+
     modal = product_page.open_pickup_locations_modal()
     modal.wait_for_map_ready()
 
-    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
+    with allure.step("Verify modal UI elements"):
+        expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
+        expect(modal.search_keyword_input, "Search input should be visible in modal").to_be_visible()
+        expect(modal.search_button, "Search button should be visible in modal").to_be_visible()
+        expect(
+            modal.pickup_locations_list,
+            "Pickup locations list should be visible in modal",
+        ).to_be_visible()
+        expect(modal.pickup_locations_map, "Google Map should be visible in modal").to_be_visible()
+        expect(
+            modal.select_address_map_desktop,
+            "Desktop layout container should be visible in modal",
+        ).to_be_visible()
+        expect(modal.close_button, "Close button should be visible in modal").to_be_visible()
 
     expect(
         modal.pickup_location_items,
         f"Pickup locations count should match GraphQL ({expected_count})",
     ).to_have_count(expected_count, timeout=10_000)
 
-    first_name = modal.get_location_name_by_index(0)
-    first_address = modal.get_location_address_by_index(0)
-    first_chip = modal.get_availability_chip_by_index(0)
+    with allure.step("Verify list content"):
+        first_name = modal.get_location_name_by_index(0)
+        first_address = modal.get_location_address_by_index(0)
+        first_chip = modal.get_availability_chip_by_index(0)
 
-    expect(first_name, "First location name should be visible").to_be_visible()
-    expect(first_address, "First location address should be visible").to_be_visible()
-    expect(first_chip, "First location availability chip should be visible").to_be_visible()
+        expect(first_name, "First location name should be visible").to_be_visible()
+        expect(first_address, "First location address should be visible").to_be_visible()
+        expect(first_chip, "First location availability chip should be visible").to_be_visible()
 
-    first_name_text = (first_name.text_content() or "").strip()
-    first_address_text = (first_address.text_content() or "").strip()
-    first_chip_text = (first_chip.text_content() or "").strip()
+        first_name_text = (first_name.text_content() or "").strip()
+        first_address_text = (first_address.text_content() or "").strip()
+        first_chip_text = (first_chip.text_content() or "").strip()
 
-    assert first_name_text, "First location name should not be empty"
-    assert first_address_text, "First location address should not be empty"
-    assert first_chip_text, "First location availability chip should not be empty"
+        assert first_name_text, "First location name should not be empty"
+        assert first_address_text, "First location address should not be empty"
+        assert first_chip_text, "First location availability chip should not be empty"
 
-    assert (
-        first_name_text in expected_names
-    ), f"First location name '{first_name_text}' should match one of the GraphQL names: {expected_names}"
+        assert (
+            first_name_text in expected_names
+        ), f"First location name '{first_name_text}' should match one of the GraphQL names: {expected_names}"
 
-    names_count = modal.pickup_location_names.count()
-    addresses_count = modal.pickup_location_addresses.count()
-    chips_count = modal.pickup_availability_chips.count()
+        names_count = modal.pickup_location_names.count()
+        addresses_count = modal.pickup_location_addresses.count()
+        chips_count = modal.pickup_availability_chips.count()
 
-    assert (
-        names_count == expected_count
-    ), f"All locations should have names, expected {expected_count}, got {names_count}"
-    assert (
-        addresses_count == expected_count
-    ), f"All locations should have addresses, expected {expected_count}, got {addresses_count}"
-    assert (
-        chips_count == expected_count
-    ), f"All locations should have availability chips, expected {expected_count}, got {chips_count}"
-
-
-_ADDRESS_FIELD_MAP = {
-    "city": "city",
-    "street": "line1",
-    "postal_code": "postalCode",
-}
-
-
-def _resolve_search_keyword(items: list[dict[str, Any]], case_id: str) -> str:
-    """Extract a search keyword from GraphQL location data for the given test case."""
-    if case_id == "full_name":
-        return items[0]["name"]
-
-    if case_id == "partial_name":
-        return items[0]["name"].split()[0]
-
-    if case_id in _ADDRESS_FIELD_MAP:
-        field = _ADDRESS_FIELD_MAP[case_id]
-        for loc in items:
-            value = (loc.get("address") or {}).get(field)
-            if value:
-                return value
-        pytest.skip(f"No location with '{case_id}' found in GraphQL data")
-
-    if case_id == "special_char":
-        for loc in items:
-            if any(ch in loc["name"] for ch in "-'.&()"):
-                return loc["name"]
-        pytest.skip("No location with special characters found in GraphQL data")
-
-    if case_id == "whitespace":
-        return f"  {items[0]['name']}  "
-
-    pytest.fail(f"Unknown search case: {case_id}")
+        assert (
+            names_count == expected_count
+        ), f"All locations should have names, expected {expected_count}, got {names_count}"
+        assert (
+            addresses_count == expected_count
+        ), f"All locations should have addresses, expected {expected_count}, got {addresses_count}"
+        assert (
+            chips_count == expected_count
+        ), f"All locations should have availability chips, expected {expected_count}, got {chips_count}"
 
 
 _ADDRESS_SEARCH_BUG_REASON = "Frontend search only matches by name, not by address fields (to be fixed by dev team)"
@@ -241,7 +186,7 @@ def test_e2e_product_pickup_locations_search_found(
     search_case_id: str,
 ):
     items = pickup_locations_data["items"]
-    keyword_to_search = _resolve_search_keyword(items, search_case_id)
+    keyword_to_search = resolve_search_keyword(items, search_case_id)
     keyword_display = keyword_to_search.strip().encode("ascii", "replace").decode()
     allure.dynamic.title(f"Search pickup locations by {search_case_id}: '{keyword_to_search.strip()}' (E2E)")
 
@@ -262,69 +207,58 @@ def test_e2e_product_pickup_locations_search_found(
         f"Initial count should match GraphQL ({expected_total})",
     ).to_have_count(expected_total, timeout=10_000)
 
-    modal.search(keyword_to_search)
+    with allure.step(f"Search by '{keyword_display}' and verify filtered results"):
+        modal.search(keyword_to_search)
+        modal.wait_for_search_results()
 
-    expect(
-        modal.pickup_location_items,
-        "Search should filter results (count should decrease from initial total)",
-    ).not_to_have_count(expected_total, timeout=10_000)
-
-    expect(
-        modal.pickup_locations_not_found,
-        "Not found message should not be visible when results exist",
-    ).not_to_be_visible()
+        expect(
+            modal.pickup_locations_not_found,
+            "Not found message should not be visible when results exist",
+        ).not_to_be_visible()
 
     filtered_count = modal.pickup_location_items.count()
     assert filtered_count > 0, f"At least one location should match keyword '{keyword_to_search.strip()}'"
-
-    keyword_normalized = keyword_to_search.strip().lower()
-    for i in range(filtered_count):
-        name_text = modal.get_location_name_by_index(i).text_content() or ""
-        address_text = modal.get_location_address_by_index(i).text_content() or ""
-        combined_text = f"{name_text} {address_text}".lower()
-        assert keyword_normalized in combined_text, (
-            f"[{search_case_id}] Location at index {i} (name='{name_text}', "
-            f"address='{address_text}') does not contain keyword '{keyword_to_search.strip()}'"
-        )
-
-
-@pytest.mark.e2e
-@allure.title("Search pickup locations with non-matching keyword on product page (E2E)")
-def test_e2e_product_pickup_locations_search_not_found(
-    product_page: ProductPage,
-):
-    print(
-        f"{os.linesep}Running E2E test to search pickup locations with non-matching keyword on product page...",
-        end=" ",
-    )
-
-    modal = product_page.open_pickup_locations_modal()
-    modal.wait_for_map_ready()
-
-    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
-
-    keyword_to_search = NON_EXISTENT_KEYWORD
-
-    modal.search(keyword_to_search)
-
-    expect(
-        modal.pickup_locations_not_found,
-        "Not found message should be visible when no locations match the search",
-    ).to_be_visible()
-
     assert (
-        modal.pickup_location_items.count() == 0
-    ), f"No pickup locations should be displayed for keyword '{keyword_to_search}'"
+        filtered_count <= expected_total
+    ), f"Search should not return more than total: got {filtered_count}, expected at most {expected_total}"
+
+    with allure.step("Verify each filtered result contains the keyword"):
+        keyword_normalized = keyword_to_search.strip().lower()
+        for i in range(filtered_count):
+            name_text = modal.get_location_name_by_index(i).text_content() or ""
+            address_text = modal.get_location_address_by_index(i).text_content() or ""
+            combined_text = f"{name_text} {address_text}".lower()
+            assert keyword_normalized in combined_text, (
+                f"[{search_case_id}] Location at index {i} (name='{name_text}', "
+                f"address='{address_text}') does not contain keyword '{keyword_to_search.strip()}'"
+            )
+
+    with allure.step("Click first filtered location and verify card dialog"):
+        first_name_text = (modal.get_location_name_by_index(0).text_content() or "").strip()
+        modal.click_location_by_index(0)
+
+        card = modal.pickup_location_card
+        expect(card.element, "Card should be visible after clicking location").to_be_visible()
+        expect(card.name, "Card name should be visible").to_be_visible()
+        expect(card.info, "Card info should be visible").to_be_visible()
+
+        card_name_text = (card.name.text_content() or "").strip()
+        assert (
+            card_name_text == first_name_text
+        ), f"Card name '{card_name_text}' should match clicked location name '{first_name_text}'"
+
+        card.close_button.click()
+        expect(card.element, "Card should be hidden after closing").not_to_be_visible()
 
 
 @pytest.mark.e2e
-@allure.title("Reset search and restore full pickup locations list on product page (E2E)")
-def test_e2e_product_pickup_locations_reset_search(
+@allure.title("Search and reset pickup locations on product page (E2E)")
+def test_e2e_product_pickup_locations_search_reset(
     product_page: ProductPage,
     pickup_locations_data: dict[str, Any],
 ):
     print(
-        f"{os.linesep}Running E2E test to reset search and restore pickup locations list on product page...",
+        f"{os.linesep}Running E2E test to search and reset pickup locations on product page...",
         end=" ",
     )
 
@@ -341,85 +275,61 @@ def test_e2e_product_pickup_locations_reset_search(
         f"Initial count should match GraphQL ({expected_total})",
     ).to_have_count(expected_total, timeout=10_000)
 
-    modal.search(keyword_to_search)
+    with allure.step("Search with a valid keyword, then clear to restore the full list"):
+        modal.search(keyword_to_search)
 
-    expect(
-        modal.pickup_location_items.first,
-        "At least one filtered result should be visible",
-    ).to_be_visible()
+        expect(
+            modal.pickup_location_items.first,
+            "At least one filtered result should be visible",
+        ).to_be_visible()
 
-    modal.clear_search()
+        modal.clear_search()
 
-    expect(
-        modal.pickup_location_items.first,
-        "First location item should be visible after reset",
-    ).to_be_visible()
-    expect(
-        modal.pickup_location_items,
-        f"Full list should be restored to {expected_total} items",
-    ).to_have_count(expected_total, timeout=10_000)
+        expect(
+            modal.pickup_location_items.first,
+            "First location item should be visible after clear",
+        ).to_be_visible()
+        expect(
+            modal.pickup_location_items,
+            f"Full list should be restored to {expected_total} items after clear",
+        ).to_have_count(expected_total, timeout=10_000)
+        expect(modal.search_keyword_input, "Search input should be empty after clear").to_have_value("")
 
-    expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
+    with allure.step("Search with a non-existent keyword, then use Reset button to restore"):
+        modal.search(NON_EXISTENT_KEYWORD)
 
+        expect(
+            modal.pickup_locations_not_found,
+            "Not found message should be visible when no locations match the search",
+        ).to_be_visible()
+        assert (
+            modal.pickup_location_items.count() == 0
+        ), f"No pickup locations should be displayed for keyword '{NON_EXISTENT_KEYWORD}'"
 
-@pytest.mark.e2e
-@allure.title("Reset search via reset button and restore full pickup locations list on product page (E2E)")
-def test_e2e_product_pickup_locations_reset_search_button(
-    product_page: ProductPage,
-    pickup_locations_data: dict[str, Any],
-):
-    print(
-        f"{os.linesep}Running E2E test to reset search via reset button on product page...",
-        end=" ",
-    )
+        expect(
+            modal.reset_search_button,
+            "Reset search button should be visible when no results found",
+        ).to_be_visible()
 
-    expected_total = pickup_locations_data["totalCount"]
+        modal.reset_search_button.click()
 
-    modal = product_page.open_pickup_locations_modal()
-    modal.wait_for_map_ready()
-
-    expect(modal.pickup_locations_list, "Pickup locations list should be visible").to_be_visible()
-
-    expect(
-        modal.pickup_location_items,
-        f"Initial count should match GraphQL ({expected_total})",
-    ).to_have_count(expected_total, timeout=10_000)
-
-    keyword_to_search = NON_EXISTENT_KEYWORD
-    modal.search(keyword_to_search)
-
-    expect(
-        modal.pickup_locations_not_found,
-        "Not found message should be visible when no locations match the search",
-    ).to_be_visible()
-    assert modal.pickup_location_items.count() == 0, "No pickup locations should be displayed"
-
-    expect(
-        modal.reset_search_button,
-        "Reset search button should be visible when no results found",
-    ).to_be_visible()
-
-    modal.reset_search_button.click()
-
-    expect(
-        modal.pickup_location_items.first,
-        "First location item should be visible after reset",
-    ).to_be_visible()
-    expect(
-        modal.pickup_location_items,
-        f"Full list should be restored to {expected_total} items",
-    ).to_have_count(expected_total, timeout=10_000)
-
-    expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
-
-    expect(
-        modal.pickup_locations_not_found,
-        "Not found message should not be visible after reset",
-    ).not_to_be_visible()
-    expect(
-        modal.reset_search_button,
-        "Reset search button should not be visible after reset",
-    ).not_to_be_visible()
+        expect(
+            modal.pickup_location_items.first,
+            "First location item should be visible after reset",
+        ).to_be_visible()
+        expect(
+            modal.pickup_location_items,
+            f"Full list should be restored to {expected_total} items after reset",
+        ).to_have_count(expected_total, timeout=10_000)
+        expect(modal.search_keyword_input, "Search input should be empty after reset").to_have_value("")
+        expect(
+            modal.pickup_locations_not_found,
+            "Not found message should not be visible after reset",
+        ).not_to_be_visible()
+        expect(
+            modal.reset_search_button,
+            "Reset search button should not be visible after reset",
+        ).not_to_be_visible()
 
 
 @pytest.mark.e2e
@@ -449,65 +359,87 @@ def test_e2e_product_pickup_locations_select_location(
     total_count = modal.pickup_location_items.count()
     assert total_count >= 2, f"Expected at least 2 pickup locations, got {total_count}"
 
-    indices_to_test = [0, 1, total_count - 1]
+    indices_to_test = sorted(set([0, 1, total_count - 1]))
     card = modal.pickup_location_card
 
     for index in indices_to_test:
-        location_name_text = modal.get_location_name_by_index(index).text_content()
-        modal.click_location_by_index(index)
+        with allure.step(f"Click location at index {index} and verify card dialog"):
+            location_name_text = modal.get_location_name_by_index(index).text_content()
+            modal.click_location_by_index(index)
 
+            expect(
+                card.element,
+                f"Card should be visible after clicking location at index {index}",
+            ).to_be_visible()
+            expect(card.name, f"Card name should be visible for location at index {index}").to_be_visible()
+            expect(card.info, f"Card info should be visible for location at index {index}").to_be_visible()
+
+            card_name_text = card.name.text_content()
+            assert (
+                card_name_text == location_name_text
+            ), f"Card name '{card_name_text}' should match clicked location name '{location_name_text}' at index {index}"
+
+            assert (
+                card_name_text in expected_names
+            ), f"Card name '{card_name_text}' should be one of the GraphQL location names: {expected_names}"
+
+            card.close_button.click()
+
+            expect(
+                card.element,
+                f"Card should be hidden after closing for location at index {index}",
+            ).not_to_be_visible()
+
+    with allure.step("Close modal and verify product page"):
         expect(
-            card.element,
-            f"Card should be visible after clicking location at index {index}",
+            modal.element,
+            "Pickup locations modal should still be visible after closing card dialog",
         ).to_be_visible()
-        expect(card.name, f"Card name should be visible for location at index {index}").to_be_visible()
-        expect(card.info, f"Card info should be visible for location at index {index}").to_be_visible()
 
-        card_name_text = card.name.text_content()
-        assert (
-            card_name_text == location_name_text
-        ), f"Card name '{card_name_text}' should match clicked location name '{location_name_text}' at index {index}"
-
-        assert (
-            card_name_text in expected_names
-        ), f"Card name '{card_name_text}' should be one of the GraphQL location names: {expected_names}"
-
-        card.close_button.click()
+        modal.close_button.click()
 
         expect(
-            card.element,
-            f"Card should be hidden after closing for location at index {index}",
+            modal.element,
+            "Pickup locations modal should not be visible after clicking close",
         ).not_to_be_visible()
 
-    expect(
-        modal.element,
-        "Pickup locations modal should still be visible after closing card dialog",
-    ).to_be_visible()
+        expect(
+            product_page.check_pickup_locations_button,
+            "Check pickup locations button should still be visible after closing modal",
+        ).to_be_visible()
 
 
 @pytest.mark.e2e
-@allure.title("Close pickup locations modal using close button on product page (E2E)")
-def test_e2e_product_pickup_locations_close_modal(
-    product_page: ProductPage,
+@allure.title("Verify pickup locations widget is NOT displayed for out-of-stock product (E2E)")
+def test_e2e_product_out_of_stock_pickup_locations_not_displayed(
+    page: Page,
+    config: Config,
+    dataset: dict[str, Any],
 ):
     print(
-        f"{os.linesep}Running E2E test to close pickup locations modal on product page...",
+        f"{os.linesep}Running E2E test to verify pickup locations widget is not displayed for out-of-stock product...",
         end=" ",
     )
 
-    modal = product_page.open_pickup_locations_modal()
-    modal.wait_for_map_ready()
+    page.set_viewport_size({"width": 1920, "height": 1080})
 
-    expect(modal.element, "Pickup locations modal should be visible").to_be_visible()
+    product = next(p for p in dataset["products"] if p["id"] == OUT_OF_STOCK_PRODUCT_ID)
+    product_page = ProductPage(page, config, build_seo_path(product, dataset))
+    product_page.navigate()
 
-    modal.close_button.click()
+    with allure.step("Verify product page loaded"):
+        expect(
+            product_page.product_name,
+            "Product name should be visible on product page",
+        ).to_be_visible()
 
-    expect(
-        modal.element,
-        "Pickup locations modal should not be visible after clicking close",
-    ).not_to_be_visible()
+    with allure.step("Verify pickup locations widget is NOT displayed for out-of-stock product"):
+        expect(
+            product_page.shipment_options_widget,
+            "Shipment options widget should NOT be visible for out-of-stock product",
+        ).not_to_be_visible()
 
-    expect(
-        product_page.check_pickup_locations_button,
-        "Check pickup locations button should still be visible after closing modal",
-    ).to_be_visible()
+        expect(
+            product_page.check_pickup_locations_button,
+            "Check pickup locations button should NOT be visible for out-of-stock product",
+        ).not_to_be_visible()

--- a/tests_e2e/tests/test_e2e_select_variant_option.py
+++ b/tests_e2e/tests/test_e2e_select_variant_option.py
@@ -16,23 +16,10 @@ from playwright.sync_api import Page, expect
 from fixtures import Auth, Config, GraphQLClient
 from graphql_operations.cart.cart_operations import CartOperations
 from graphql_operations.user.user_operations import UserOperations
+from tests_e2e.helpers import build_seo_path
 from tests_e2e.pages import ProductPage
 
 SPORT_BAND_PRODUCT_ID = "product-b2c-test-sport-band"
-
-
-def _build_seo_path(product: dict, dataset: dict) -> str:
-    """Build full SEO path from category hierarchy + product semantic URL."""
-    categories_by_id = {c["id"]: c for c in dataset["categories"]}
-    parts = []
-    category_id = product["categoryId"]
-    while category_id:
-        cat = categories_by_id[category_id]
-        parts.append(cat["seoInfos"][0]["semanticUrl"])
-        category_id = cat.get("parentId")
-    parts.reverse()
-    parts.append(product["seoInfos"][0]["semanticUrl"])
-    return "/".join(parts)
 
 
 def _find_variation(dataset: dict, color: str, size: str, wrist_size: str) -> dict:
@@ -87,7 +74,7 @@ def test_e2e_select_variant_option(
         wrist_size_prop = next(p for p in variation_props if p["name"] == "WristSize")
         wrist_size_value = wrist_size_prop["values"][0]["value"]  # S/M
 
-        seo_path = _build_seo_path(product, dataset)
+        seo_path = build_seo_path(product, dataset)
 
         user_operations = UserOperations(graphql_client)
         user = user_operations.get_me()
@@ -190,7 +177,7 @@ def test_e2e_variant_title_and_price_change(
         second_variation = _find_variation(dataset, second_color, size_value, wrist_size_value)
         second_expected_price = _get_variation_price_usd(dataset, second_variation["id"])
 
-        seo_path = _build_seo_path(product, dataset)
+        seo_path = build_seo_path(product, dataset)
 
         user_operations = UserOperations(graphql_client)
         user = user_operations.get_me()
@@ -287,7 +274,7 @@ def test_e2e_add_variant_combinations_to_cart(
             var = _find_variation(dataset, combo["color"], combo["size"], combo["wrist_size"])
             variations.append(var)
 
-        seo_path = _build_seo_path(product, dataset)
+        seo_path = build_seo_path(product, dataset)
 
     with allure.step("Authenticate and open product page"):
         user_operations = UserOperations(graphql_client)

--- a/tests_graphql/tests/test_graphql_invite_user.py
+++ b/tests_graphql/tests/test_graphql_invite_user.py
@@ -19,6 +19,7 @@ DEFAULT_ROLE_ID = "org-employee"
 INDEXING_WAIT_SECONDS = 10
 
 
+@pytest.mark.ignore
 @pytest.mark.graphql
 @allure.feature("Invite user (GraphQL)")
 def test_invite_user(

--- a/tests_graphql/tests/test_graphql_reset_password.py
+++ b/tests_graphql/tests/test_graphql_reset_password.py
@@ -41,7 +41,6 @@ def test_reset_password(
     )
 
     assert send_password_reset_email_result is True
-   
 
     auth.authenticate(config["ADMIN_USERNAME"], config["ADMIN_PASSWORD"])
 
@@ -63,7 +62,7 @@ def test_reset_password(
     notification_id = search_reset_password_email_notification["results"][0]["id"]
     print(f"{os.linesep}Notification ID: {notification_id}")
 
-    sleep(20)
+    sleep(5)
 
     notification = webapi_client.get(
         f"/api/notifications/journal/{notification_id}",
@@ -72,13 +71,11 @@ def test_reset_password(
     assert notification is not None
     assert notification["notificationType"] == "ResetPasswordEmailNotification"
     assert notification["to"] == dataset["users"][2]["email"]
-    assert notification["subject"] is not None and notification["subject"].startswith(
-        "Reset password link"
-    )
+    assert notification["subject"] is not None and notification["subject"].startswith("Reset password link")
     assert notification["body"] is not None
     if notification["status"] != "Sent":
         pytest.fail(f"Notification status is not Sent: {notification['lastSendError']}")
-   
+
     # Extract and set Token from URL
     body_html = notification["body"]
 


### PR DESCRIPTION
Add 11 E2E tests covering the pickup locations modal on the product page: modal elements, list content, search found/not found, reset search (clear input and reset button), select multiple locations, and close modal.