### PR TITLE
feat: add E2E test for adding variations to cart from category list view

### DIFF
--- a/tests_e2e/components/__init__.py
+++ b/tests_e2e/components/__init__.py
@@ -29,6 +29,7 @@ from .select_address_modal_component import SelectAddressModalComponent
 from .select_bopis_map_modal_component import SelectBopisMapModalComponent
 from .top_header_account_menu_component import TopHeaderAccountMenuComponent
 from .top_header_component import TopHeaderComponent
+from .variation_line_item_component import VariationLineItemComponent
 from .variation_option_component import VariationOptionComponent
 from .variation_selector_component import VariationSelectorComponent
 
@@ -64,6 +65,7 @@ __all__ = [
     "SearchHistorySectionItemComponent",
     "SearchProductsSectionComponent",
     "SearchProductsSectionItemComponent",
+    "VariationLineItemComponent",
     "VariationOptionComponent",
     "VariationSelectorComponent",
 ]

--- a/tests_e2e/components/product_card_component.py
+++ b/tests_e2e/components/product_card_component.py
@@ -2,6 +2,7 @@ from playwright.sync_api import Locator
 
 from .add_to_cart_component import AddToCartComponent
 from .quantity_stepper_component import QuantityStepperComponent
+from .variation_line_item_component import VariationLineItemComponent
 
 
 class ProductCardComponent:
@@ -14,16 +15,33 @@ class ProductCardComponent:
 
     @property
     def add_to_cart_component(self) -> AddToCartComponent:
-        return AddToCartComponent(
-            self.element.locator("[data-test-id='add-to-cart-component']")
-        )
+        return AddToCartComponent(self.element.locator("[data-test-id='add-to-cart-component']"))
 
     @property
     def quantity_stepper_component(self) -> QuantityStepperComponent:
-        return QuantityStepperComponent(
-            self.element.locator(".vc-quantity-stepper__input")
-        )
+        return QuantityStepperComponent(self.element.locator(".vc-quantity-stepper__input"))
 
     @property
     def count_in_cart_label(self) -> Locator:
         return self.element.locator("[data-test-id='count-in-cart-label']")
+
+    @property
+    def variations_button(self) -> Locator:
+        return self.element.locator("[data-test-id='product-card-variations-button']")
+
+    @property
+    def variants_wrapper(self) -> Locator:
+        return self.element.locator("[data-test-id='product-card-variants-wrapper']")
+
+    @property
+    def variation_line_items(self) -> list[VariationLineItemComponent]:
+        return [
+            VariationLineItemComponent(item)
+            for item in self.variants_wrapper.locator("[data-test-id='line-item']").all()
+        ]
+
+    def get_variation_line_item_by_name(self, name: str) -> VariationLineItemComponent | None:
+        for item in self.variation_line_items:
+            if item.name == name:
+                return item
+        return None

--- a/tests_e2e/components/variation_line_item_component.py
+++ b/tests_e2e/components/variation_line_item_component.py
@@ -1,0 +1,36 @@
+from playwright.sync_api import Locator
+
+
+class VariationLineItemComponent:
+
+    def __init__(self, element: Locator):
+        self.element = element
+
+    @property
+    def name(self) -> str:
+        text = self.element.locator(".vc-line-item__name").text_content()
+        return text.strip() if text else ""
+
+    @property
+    def name_locator(self) -> Locator:
+        return self.element.locator(".vc-line-item__name")
+
+    @property
+    def quantity_stepper_input(self) -> Locator:
+        return self.element.locator("[data-test-id='quantity-stepper-input']")
+
+    @property
+    def quantity_stepper_decrement(self) -> Locator:
+        return self.element.locator("[data-test-id='quantity-stepper-decrement']")
+
+    @property
+    def quantity_stepper_increment(self) -> Locator:
+        return self.element.locator("[data-test-id='quantity-stepper-increment']")
+
+    @property
+    def quantity_input(self) -> Locator:
+        return self.element.locator("[data-test-id='quantity-stepper-input'] input")
+
+    @property
+    def count_in_cart_label(self) -> Locator:
+        return self.element.locator("[data-test-id='count-in-cart-label']")

--- a/tests_e2e/pages/category_page.py
+++ b/tests_e2e/pages/category_page.py
@@ -18,8 +18,8 @@ class CategoryPage(MainLayoutPage):
         page: Page,
         seo_path: str,
     ):
+        super().__init__(page)
         self.config = config
-        self.page = page
         self.seo_path = seo_path
 
     @property
@@ -28,9 +28,7 @@ class CategoryPage(MainLayoutPage):
 
     @property
     def view_switcher(self) -> CategoryViewSwitcherComponent:
-        return CategoryViewSwitcherComponent(
-            self.page.locator("[data-test-id='category-page.view-switcher']")
-        )
+        return CategoryViewSwitcherComponent(self.page.locator("[data-test-id='category-page.view-switcher']"))
 
     @property
     def products_grid_view(self) -> Locator:
@@ -41,20 +39,25 @@ class CategoryPage(MainLayoutPage):
         return self.page.locator("[data-test-id='category-page.products-list-view']")
 
     @property
-    def product_cards(self) -> list[ProductCardComponent]:
+    def product_cards_grid(self) -> list[ProductCardComponent]:
         return [
             ProductCardComponent(card)
-            for card in self.products_grid_view.locator(
-                "[data-test-id='product-card']"
-            ).all()
+            for card in self.products_grid_view.locator("[data-test-id='product-card']").all()
         ]
 
     @property
-    def price_filter_slider(self) -> FilterSliderComponent | None:
+    def product_cards_list(self) -> list[ProductCardComponent]:
+        return [
+            ProductCardComponent(card)
+            for card in self.products_list_view.locator("[data-test-id='product-card']").all()
+        ]
+
+    @property
+    def price_filter_slider(self) -> FilterSliderComponent:
         return FilterSliderComponent(self.page.locator("[data-test-id='filter-price']"))
 
     @property
-    def price_filter_facets(self) -> FilterFacetComponent | None:
+    def price_filter_facets(self) -> FilterFacetComponent:
         return FilterFacetComponent(self.page.locator("[data-test-id='filter-price']"))
 
     @property
@@ -65,12 +68,18 @@ class CategoryPage(MainLayoutPage):
     def products_count_locator(self) -> Locator:
         return self.page.locator(".category__products-count .me-1")
 
-    def navigate(self) -> None:
-        self.page.goto(f"{self.url}?sort=price-ascending")
+    def navigate(self, sort: str = "price-ascending") -> None:
+        self.page.goto(f"{self.url}?sort={sort}")
         self.page.wait_for_load_state("networkidle")
 
-    def get_product_card_by_sku(self, sku: str) -> ProductCardComponent | None:
-        for product_card in self.product_cards:
+    def get_product_card_by_sku_grid(self, sku: str) -> ProductCardComponent | None:
+        for product_card in self.product_cards_grid:
+            if product_card.sku == sku:
+                return product_card
+        return None
+
+    def get_product_card_by_sku_list(self, sku: str) -> ProductCardComponent | None:
+        for product_card in self.product_cards_list:
             if product_card.sku == sku:
                 return product_card
         return None

--- a/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
+++ b/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
@@ -1,0 +1,137 @@
+"""
+E2E tests for adding product variations to cart from the category list view.
+
+Test Cases:
+- test_e2e_add_variation_to_cart_from_list_view: Switch to list view, expand variations,
+  add two variations to cart, and verify cart badge and count-in-cart labels.
+"""
+
+import os
+from typing import Any
+
+import allure
+import pytest
+from playwright.sync_api import Page, expect
+
+from fixtures import Auth, Config, GraphQLClient
+from graphql_operations.cart.cart_operations import CartOperations
+from graphql_operations.user.user_operations import UserOperations
+from tests_e2e.pages import CartPage, CategoryPage
+
+SMART_WATCHES_SEO_PATH = "smart-watches"
+PRODUCT_SKU = "B2B-SIMPLE-001"
+VARIATION_NAME_RED = "B2B Simple Product - Red"
+VARIATION_NAME_BLUE = "B2B Simple Product - Blue"
+
+
+@pytest.mark.e2e
+@allure.title("Add variations to cart from category list view (E2E)")
+def test_e2e_add_variation_to_cart_from_list_view(
+    config: Config,
+    auth: Auth,
+    graphql_client: GraphQLClient,
+    page: Page,
+    dataset: dict[str, Any],
+):
+
+    print(f"{os.linesep}Running E2E test to add variations to cart from list view...", end=" ")
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    user_operations = UserOperations(graphql_client)
+    cart_operations = CartOperations(graphql_client)
+
+    with allure.step("Authenticate as regular user"):
+        dataset_user = dataset["users"][0]
+        auth.authenticate(dataset_user["userName"], config["USERS_PASSWORD"], page)
+        user = user_operations.get_me()
+
+    with allure.step("Navigate to Smart Watches category and switch to list view"):
+        category_page = CategoryPage(config, page, SMART_WATCHES_SEO_PATH)
+        category_page.navigate()
+
+        category_page.view_switcher.switch_category_view("list")
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            category_page.products_list_view,
+            "Products list view should be visible after switching to list view",
+        ).to_be_visible()
+
+    with allure.step(f"Find product card for SKU {PRODUCT_SKU} and expand variations"):
+        product_card = category_page.get_product_card_by_sku_list(PRODUCT_SKU)
+        assert product_card is not None, f"Product card with SKU '{PRODUCT_SKU}' not found in list view"
+
+        expect(
+            product_card.variations_button,
+            "Variations button should be visible on the product card in list view",
+        ).to_be_visible()
+
+        product_card.variations_button.click()
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            product_card.variants_wrapper,
+            "Variants wrapper should be visible after clicking the variations button",
+        ).to_be_visible()
+
+        expect(
+            product_card.variants_wrapper.locator("[data-test-id='line-item']").first,
+            "At least one variation line item should be visible",
+        ).to_be_visible()
+
+    try:
+        with allure.step(f"Add '{VARIATION_NAME_RED}' to cart"):
+            variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
+            assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
+
+            variation_red.quantity_stepper_increment.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(
+                variation_red.count_in_cart_label,
+                f"Count in cart label should be visible for '{VARIATION_NAME_RED}'",
+            ).to_be_visible()
+            expect(
+                variation_red.count_in_cart_label,
+                f"Count in cart label should show '1' for '{VARIATION_NAME_RED}'",
+            ).to_have_text("1")
+
+        with allure.step(f"Add '{VARIATION_NAME_BLUE}' to cart"):
+            variation_blue = product_card.get_variation_line_item_by_name(VARIATION_NAME_BLUE)
+            assert variation_blue is not None, f"Variation line item '{VARIATION_NAME_BLUE}' not found"
+
+            variation_blue.quantity_stepper_increment.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(
+                variation_blue.count_in_cart_label,
+                f"Count in cart label should be visible for '{VARIATION_NAME_BLUE}'",
+            ).to_be_visible()
+            expect(
+                variation_blue.count_in_cart_label,
+                f"Count in cart label should show '1' for '{VARIATION_NAME_BLUE}'",
+            ).to_have_text("1")
+
+        with allure.step("Verify cart badge shows 2 items"):
+            expect(
+                category_page.cart_badge,
+                "Cart badge should show '2' after adding two variations",
+            ).to_have_text("2")
+
+    finally:
+        with allure.step("Cleanup: remove cart"):
+            cart = cart_operations.get_cart(
+                store_id=config["STORE_ID"],
+                user_id=user["id"],
+                currency_code="USD",
+                culture_name="en-US",
+            )
+            if cart and cart.get("id"):
+                cart_operations.remove_cart(
+                    payload={
+                        "cartId": cart["id"],
+                        "userId": user["id"],
+                    }
+                )
+            auth.clear_token()

--- a/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
+++ b/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
@@ -1,9 +1,11 @@
 """
-E2E tests for adding product variations to cart from the category list view.
+E2E tests for adding and updating product variations in cart from the category list view.
 
 Test Cases:
 - test_e2e_add_variation_to_cart_from_list_view: Switch to list view, expand variations,
   add two variations to cart, and verify cart badge and count-in-cart labels.
+- test_e2e_update_variation_quantity_from_list_view: Switch to list view, expand variations,
+  add a variation to cart, increment and decrement quantity, verify updates.
 """
 
 import os
@@ -118,6 +120,106 @@ def test_e2e_add_variation_to_cart_from_list_view(
                 category_page.cart_badge,
                 "Cart badge should show '2' after adding two variations",
             ).to_have_text("2")
+
+    finally:
+        with allure.step("Cleanup: remove cart"):
+            cart = cart_operations.get_cart(
+                store_id=config["STORE_ID"],
+                user_id=user["id"],
+                currency_code="USD",
+                culture_name="en-US",
+            )
+            if cart and cart.get("id"):
+                cart_operations.remove_cart(
+                    payload={
+                        "cartId": cart["id"],
+                        "userId": user["id"],
+                    }
+                )
+            auth.clear_token()
+
+
+@pytest.mark.e2e
+@allure.title("Update variation quantity in cart from category list view (E2E)")
+def test_e2e_update_variation_quantity_from_list_view(
+    config: Config,
+    auth: Auth,
+    graphql_client: GraphQLClient,
+    page: Page,
+    dataset: dict[str, Any],
+):
+
+    print(f"{os.linesep}Running E2E test to update variation quantity from list view...", end=" ")
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    user_operations = UserOperations(graphql_client)
+    cart_operations = CartOperations(graphql_client)
+
+    with allure.step("Authenticate as regular user"):
+        dataset_user = dataset["users"][0]
+        auth.authenticate(dataset_user["userName"], config["USERS_PASSWORD"], page)
+        user = user_operations.get_me()
+
+    with allure.step("Navigate to Smart Watches category and switch to list view"):
+        category_page = CategoryPage(config, page, SMART_WATCHES_SEO_PATH)
+        category_page.navigate()
+
+        category_page.view_switcher.switch_category_view("list")
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            category_page.products_list_view,
+            "Products list view should be visible after switching to list view",
+        ).to_be_visible()
+
+    with allure.step(f"Find product card for SKU {PRODUCT_SKU} and expand variations"):
+        product_card = category_page.get_product_card_by_sku_list(PRODUCT_SKU)
+        assert product_card is not None, f"Product card with SKU '{PRODUCT_SKU}' not found in list view"
+
+        expect(
+            product_card.variations_button,
+            "Variations button should be visible on the product card in list view",
+        ).to_be_visible()
+
+        product_card.variations_button.click()
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            product_card.variants_wrapper.locator("[data-test-id='line-item']").first,
+            "At least one variation line item should be visible",
+        ).to_be_visible()
+
+    try:
+        with allure.step(f"Add '{VARIATION_NAME_RED}' to cart (quantity 1)"):
+            variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
+            assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
+
+            variation_red.quantity_stepper_increment.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '1'").to_have_text("1")
+
+        with allure.step(f"Increment '{VARIATION_NAME_RED}' quantity to 2"):
+            variation_red.quantity_stepper_increment.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '2'").to_have_value("2")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '2'").to_have_text("2")
+
+        with allure.step(f"Decrement '{VARIATION_NAME_RED}' quantity back to 1"):
+            variation_red.quantity_stepper_decrement.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '1'").to_have_text("1")
+
+        with allure.step("Verify cart badge shows 1 item"):
+            expect(
+                category_page.cart_badge,
+                "Cart badge should show '1' after updating variation quantity",
+            ).to_have_text("1")
 
     finally:
         with allure.step("Cleanup: remove cart"):

--- a/tests_e2e/tests/test_e2e_category_add_to_cart_viewport.py
+++ b/tests_e2e/tests/test_e2e_category_add_to_cart_viewport.py
@@ -29,7 +29,7 @@ def test_e2e_category_add_to_cart_component_viewport(
 
     category_page.view_switcher.switch_category_view("grid")
 
-    product_card = category_page.get_product_card_by_sku(product["code"])
+    product_card = category_page.get_product_card_by_sku_grid(product["code"])
 
     expect(product_card.element).to_be_visible(), "Product card is not visible"
 

--- a/tests_e2e/tests/test_e2e_category_page_add_product_to_cart.py
+++ b/tests_e2e/tests/test_e2e_category_page_add_product_to_cart.py
@@ -42,7 +42,7 @@ def test_e2e_category_add_product_to_cart_with_add_to_cart_button(
     category_page = CategoryPage(config, page, category["seoInfos"][0]["semanticUrl"])
     category_page.navigate()
 
-    product_card = category_page.get_product_card_by_sku(product["code"])
+    product_card = category_page.get_product_card_by_sku_grid(product["code"])
     product_card.add_to_cart_component.quantity_input.fill(quantity_to_add)
     product_card.add_to_cart_component.add_to_cart_text_button.click()
 
@@ -110,7 +110,7 @@ def test_e2e_category_add_product_to_cart_with_quantity_stepper(
     category_page = CategoryPage(config, page, category["seoInfos"][0]["semanticUrl"])
     category_page.navigate()
 
-    product_card = category_page.get_product_card_by_sku(product["code"])
+    product_card = category_page.get_product_card_by_sku_grid(product["code"])
     product_card.quantity_stepper_component.increment_button.click()
     product_card.quantity_stepper_component.increment_button.click()
 


### PR DESCRIPTION
New test verifies switching to list view, expanding product variations, adding Red and Blue variations to cart, and asserting cart badge count.

- Add VariationLineItemComponent for variation row interactions
- Extend ProductCardComponent with variations_button, variants_wrapper
- Refactor CategoryPage: rename product_cards/get_product_card_by_sku to grid/list variants, add super().__init__(), parameterize navigate sort
- Update existing tests for renamed grid methods