### PR TITLE
Refactor: replace imperative config branching with declarative pytest markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is an enterprise-grade test automation framework for VirtoCommerce e-commerce platform. It uses Playwright and Python to provide end-to-end testing capabilities for both GraphQL API and UI layers.
+Test automation framework for VirtoCommerce e-commerce platform. Uses Playwright + Python + pytest for GraphQL API and E2E UI testing.
 
 ## Common Commands
 
 ### Running Tests
-
-**Create and activate a virtual environment**
-
-   ```sh
-   python -m venv .venv
-   source .venv/bin/activate  # On macOS/Linux
-   .venv\Scripts\activate     # On Windows
-   ```
 
 ```bash
 # Run all GraphQL tests
@@ -37,11 +29,8 @@ pytest tests_graphql/tests/test_graphql_add_item_to_cart.py::test_add_item_to_an
 # Run by marker (exclude ignored tests)
 pytest -m "graphql and not ignore"
 pytest -m "e2e and not ignore"
-```
 
-### Browser Selection
-
-```bash
+# Browser selection
 pytest --browser=chromium   # Default
 pytest --browser=firefox
 pytest --browser=webkit
@@ -58,8 +47,10 @@ pytest --browser=webkit
 ### Code Quality
 
 ```bash
-pre-commit run --all-files  # Run Black formatter and other checks
+pre-commit run --all-files  # Run Black formatter (120 char line length)
 ```
+
+Note: Black is the **only** pre-commit hook (no isort/flake8/mypy in pre-commit despite isort being in requirements.txt).
 
 ### Utility Commands
 
@@ -75,70 +66,151 @@ python -m dataset.dataset_manager --seed currencies languages fulfillment_center
 
 # Fetch payloads without seeding
 python -m dataset.dataset_manager
-
-# Record Playwright tests
-playwright codegen https://your-frontend-url.com
 ```
 
 ## Architecture
 
 ### Directory Structure
 
-- **tests_graphql/tests/** - GraphQL API functional tests (54 tests)
-- **tests_e2e/tests/** - End-to-end UI tests (25 tests)
-- **tests_e2e/pages/** - Page Object Model classes
-- **tests_e2e/components/** - Reusable UI component wrappers
+- **tests_graphql/tests/** - GraphQL API functional tests
+- **tests_e2e/tests/** - End-to-end UI tests
+- **tests_e2e/pages/** - Page Object Model classes (inherit from `MainLayoutPage`)
+- **tests_e2e/components/** - Reusable UI component wrappers (~38 components)
+- **tests_webapi/tests/** - Web API platform tests
 - **graphql_client/** - Auto-generated type-safe GraphQL client (mutations/, queries/, types/)
-- **graphql_operations/** - High-level GraphQL operation wrappers organized by domain (cart, catalog, user, order, etc.)
+- **graphql_operations/** - High-level GraphQL operation wrappers organized by domain
 - **fixtures/** - Pytest fixtures (auth, config, graphql_client, dataset, requests_tracker, webapi_client)
-- **dataset/data/** - JSON test data configuration files for seeding
+- **dataset/data/** - JSON test data configuration files for seeding (29 entity files)
 
-### Key Patterns
+### Declarative Feature Markers (Key Pattern)
 
-**Test Markers:** Tests must use appropriate pytest markers:
+Tests declare their required configuration via pytest markers instead of branching on config values at runtime. The `pytest_runtest_setup` hook in `conftest.py` auto-skips tests when their marker doesn't match the current config:
+
+```python
+# In conftest.py - maps marker names to config keys
+FEATURE_MARKERS = {
+    "checkout_mode": "CHECKOUT_MODE",
+    "quantity_control": "PRODUCT_QUANTITY_CONTROL",
+    "range_filter": "RANGE_FILTER_TYPE",
+}
+```
+
+**Usage in tests:**
+```python
+@pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")      # Skipped if CHECKOUT_MODE != "single-page"
+@pytest.mark.quantity_control("stepper")        # Skipped if PRODUCT_QUANTITY_CONTROL != "stepper"
+def test_example(page, config):
+    ...
+```
+
+This replaces imperative `if config["CHECKOUT_MODE"] == "single-page"` branching. When writing new tests that depend on a specific checkout mode, quantity control, or range filter type, always use the declarative marker.
+
+### Test Markers
+
+Tests must use appropriate pytest markers:
 - `@pytest.mark.graphql` - GraphQL API tests
 - `@pytest.mark.e2e` - End-to-end UI tests
 - `@pytest.mark.webapi` - Web API tests
 - `@pytest.mark.ignore` - Tests to skip
+- `@pytest.mark.checkout_mode("single-page"|"multi-step")` - Requires specific checkout mode
+- `@pytest.mark.quantity_control("stepper"|"button")` - Requires specific quantity control
+- `@pytest.mark.range_filter("slider"|"default")` - Requires specific range filter type
 
-**GraphQL Test Pattern:**
+### GraphQL Two-Layer Architecture
+
+**Layer 1 - `graphql_client/`** (auto-generated): Raw query/mutation classes with parametrized `return_fields` string. Each class accepts a GraphQL client and executes a single operation.
+
+**Layer 2 - `graphql_operations/`** (handwritten): Domain operation classes (CartOperations, CatalogOperations, UserOperations, etc.) that compose Layer 1 classes with fragment constants.
+
+**Fragment system:** `graphql_operations/*/fragments/` contains Python string constants for GQL field selection sets. Operations pass these to `return_fields` rather than hardcoding field selections.
+
+**Important:** `graphql_client.execute()` returns plain Python `dict`s, not typed instances. Access fields as `cart["id"]`, not `cart.id`.
+
 ```python
+# GraphQL test pattern
 @pytest.mark.graphql
 def test_example(graphql_client, config, dataset):
-    operations = SomeOperations(graphql_client)
-    response = operations.do_something(payload)
-    assert response["field"] is not None
+    operations = CartOperations(graphql_client)
+    result = operations.add_item_to_cart(payload)
+    assert result["id"] is not None
 ```
 
-**E2E Test Pattern:**
+### Page Object Model & Components
+
+**Pages** inherit from `MainLayoutPage` which provides shared header elements (cart link, account menu, search bar, language/currency selectors). Constructor takes `(page, config)`. URL is a `@property` from config. `navigate()` does `goto()` + `wait_for_load_state("networkidle")`.
+
+**Components** wrap a root `Locator` and expose sub-elements as `@property`. They are page-agnostic (no page reference, all locators relative to `self.element`). Key components:
+- `QuantityStepperComponent` - for `quantity_control=stepper`
+- `AddToCartComponent` - for `quantity_control=button`
+- Both appear in `LineItemComponent`, `ProductCardComponent`, `VariationLineItemComponent`
+
+**Locator strategy:** All element locators use `data-test-id` attributes (e.g., `[data-test-id='line-item']`).
+
+### E2E Authentication Patterns
+
+**Full page auth** (checkout/order tests):
+```python
+auth.authenticate(dataset["users"][0]["userName"], config["USERS_PASSWORD"], page)
+```
+Sets HTTP headers + localStorage (`auth` token + `user-id`).
+
+**Headless cart setup + page handoff** (simpler cart tests):
+```python
+# Set up cart server-side via GraphQL
+cart_operations.add_item_to_cart(...)
+# Give only user-id to page to find the cart
+auth.set_local_storage_user_id(page, user["id"])
+```
+
+**GraphQL-only auth** (no page):
+```python
+auth.authenticate(username, password)  # No page argument
+# ... do GraphQL operations ...
+auth.clear_token()  # Cleanup
+```
+
+### E2E Test Pattern
+
 ```python
 @pytest.mark.e2e
-def test_example(page, config):
-    page_object = SomePage(page, config)
-    page_object.navigate()
-    expect(page).to_have_url(page_object.url)
+@allure.title("Test description for Allure report")
+def test_example(page, config, auth, dataset, graphql_client):
+    with allure.step("Setup"):
+        # Auth + data setup
+    with allure.step("Action"):
+        page_object = SomePage(page, config)
+        page_object.navigate()
+    with allure.step("Assertion"):
+        expect(page).to_have_url(page_object.url)
 ```
+
+Tests use `@allure.title()` and `with allure.step()` blocks for structured Allure reports.
 
 ### Configuration
 
-- Environment variables loaded from `.env` file
+- Environment variables loaded from `.env` file (OS env vars override `.env`)
 - Config fixture provides access: `config["FRONTEND_BASE_URL"]`, `config["BACKEND_BASE_URL"]`, `config["STORE_ID"]`
-- Defaults defined in `fixtures/config.py`: CHECKOUT_MODE, PRODUCT_QUANTITY_CONTROL, RANGE_FILTER_TYPE
+- Defaults defined in `fixtures/config.py`: `CHECKOUT_MODE=single-page`, `PRODUCT_QUANTITY_CONTROL=stepper`, `RANGE_FILTER_TYPE=slider`
+- Required `.env` vars: `FRONTEND_BASE_URL`, `BACKEND_BASE_URL`, `STORE_ID`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `USERS_PASSWORD`
 
-### Dataset Placeholders
+### Dataset System
 
-In `dataset/data/*.json` files:
-- `{ENV:VARIABLE_NAME}` - Substitutes value from .env file
-- `{PAYLOAD_ITEM:property}` - Substitutes value from current data item
+- JSON files in `dataset/data/` define seed requests with `method`, `endpoint`, `payload_type`, `data`, optional `priority`
+- File stems are converted to camelCase keys: `product_inventories.json` → `dataset["productInventories"]`
+- Placeholders: `{ENV:VARIABLE_NAME}` (from .env), `{PAYLOAD_ITEM:property}` (from current data item)
+- Seeding respects `priority` field for dependency ordering (lower = first)
+- `payload_type="single"` sends one request per item; `payload_type="array"` sends all items in one request
 
-### Code Formatting
+### Fixture Scopes
 
-Black formatter with 120-character line length (enforced via pre-commit hooks).
+- **Session-scoped:** `config`, `auth`, `graphql_client`, `dataset`, `webapi_client`, `browser_context_args`, `browser_type_launch_args`
+- **Function-scoped:** `requests_tracker`, `screenshot_on_failure` (autouse)
 
-## Test Retry and Reporting
+### Test Retry and Reporting
 
-- Automatic retry: 1 retry configured in pytest.ini
-- Screenshots captured on failure to `screenshots/failures/`
-- Allure reporting: results saved to `allure-results/`
+- Automatic retry: 1 retry configured in pytest.ini (`--retries=1`)
+- Screenshots captured on failure to `screenshots/failures/` and attached to Allure
+- Allure reporting: results saved to `allure-results/` (cleaned each run via `--clean-alluredir`)
 - Default expect timeout: 30 seconds
 - Default viewport: 1440x900

--- a/conftest.py
+++ b/conftest.py
@@ -14,8 +14,35 @@ from fixtures import (
     requests_tracker,
     webapi_client,
 )
+from fixtures.config import Config
 
 load_dotenv(override=True)
+
+FEATURE_MARKERS = {
+    "checkout_mode": "CHECKOUT_MODE",
+    "quantity_control": "PRODUCT_QUANTITY_CONTROL",
+    "range_filter": "RANGE_FILTER_TYPE",
+}
+
+_config_instance = None
+
+
+def _get_config():
+    global _config_instance
+    if _config_instance is None:
+        _config_instance = Config()
+    return _config_instance
+
+
+def pytest_runtest_setup(item):
+    cfg = _get_config()
+    for marker_name, config_key in FEATURE_MARKERS.items():
+        marker = item.get_closest_marker(marker_name)
+        if marker:
+            required_value = marker.args[0]
+            actual_value = cfg[config_key]
+            if actual_value != required_value:
+                pytest.skip(f"Requires {marker_name}={required_value}, got {actual_value}")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -117,9 +144,7 @@ def authenticated_page(auth_token, config, browser_context):
 
     # Set auth object in localStorage
     page = browser_context.new_page()
-    page.goto(
-        config["frontend_base_url"]
-    )  # Wait for page load before manipulating storage
+    page.goto(config["frontend_base_url"])  # Wait for page load before manipulating storage
     page.evaluate(
         f"""
         localStorage.setItem('auth', JSON.stringify({auth_token[1]}));

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ markers =
     webapi: mark a test as a webapi scenario
     e2e: mark a test as an end-to-end scenario
     ignore: mark a test as ignored
+    checkout_mode(mode): test requires specific checkout mode (single-page or multi-step)
+    quantity_control(type): test requires specific quantity control (stepper or button)
+    range_filter(type): test requires specific range filter type (slider or default)

--- a/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
+++ b/tests_e2e/tests/test_e2e_add_variations_to_cart_from_list_view.py
@@ -2,10 +2,12 @@
 E2E tests for adding and updating product variations in cart from the category list view.
 
 Test Cases:
-- test_e2e_add_variation_to_cart_from_list_view: Switch to list view, expand variations,
-  add two variations to cart, and verify cart badge and count-in-cart labels.
-- test_e2e_update_variation_quantity_from_list_view: Switch to list view, expand variations,
-  add a variation to cart, increment and decrement quantity, verify updates.
+- test_e2e_add_variation_to_cart_from_list_view_stepper: Switch to list view, expand variations,
+  add two variations to cart using stepper, and verify cart badge and count-in-cart labels.
+- test_e2e_add_variation_to_cart_from_list_view_button: Same flow using add-to-cart button.
+- test_e2e_update_variation_quantity_from_list_view_stepper: Switch to list view, expand variations,
+  add a variation to cart using stepper, increment and decrement quantity, verify updates.
+- test_e2e_update_variation_quantity_from_list_view_button: Same flow using add-to-cart button.
 """
 
 import os
@@ -27,8 +29,9 @@ VARIATION_NAME_BLUE = "B2B Simple Product - Blue"
 
 
 @pytest.mark.e2e
-@allure.title("Add variations to cart from category list view (E2E)")
-def test_e2e_add_variation_to_cart_from_list_view(
+@pytest.mark.quantity_control("stepper")
+@allure.title("Add variations to cart from category list view with stepper (E2E)")
+def test_e2e_add_variation_to_cart_from_list_view_stepper(
     config: Config,
     auth: Auth,
     graphql_client: GraphQLClient,
@@ -36,7 +39,7 @@ def test_e2e_add_variation_to_cart_from_list_view(
     dataset: dict[str, Any],
 ):
 
-    print(f"{os.linesep}Running E2E test to add variations to cart from list view...", end=" ")
+    print(f"{os.linesep}Running E2E test to add variations to cart from list view with stepper...", end=" ")
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -87,10 +90,7 @@ def test_e2e_add_variation_to_cart_from_list_view(
             variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
             assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
 
-            if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-                variation_red.add_to_cart_component.add_to_cart_text_button.click()
-            else:
-                variation_red.quantity_stepper_increment.click()
+            variation_red.quantity_stepper_increment.click()
             page.wait_for_load_state("networkidle")
 
             expect(
@@ -106,10 +106,7 @@ def test_e2e_add_variation_to_cart_from_list_view(
             variation_blue = product_card.get_variation_line_item_by_name(VARIATION_NAME_BLUE)
             assert variation_blue is not None, f"Variation line item '{VARIATION_NAME_BLUE}' not found"
 
-            if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-                variation_blue.add_to_cart_component.add_to_cart_text_button.click()
-            else:
-                variation_blue.quantity_stepper_increment.click()
+            variation_blue.quantity_stepper_increment.click()
             page.wait_for_load_state("networkidle")
 
             expect(
@@ -146,8 +143,9 @@ def test_e2e_add_variation_to_cart_from_list_view(
 
 
 @pytest.mark.e2e
-@allure.title("Update variation quantity in cart from category list view (E2E)")
-def test_e2e_update_variation_quantity_from_list_view(
+@pytest.mark.quantity_control("button")
+@allure.title("Add variations to cart from category list view with button (E2E)")
+def test_e2e_add_variation_to_cart_from_list_view_button(
     config: Config,
     auth: Auth,
     graphql_client: GraphQLClient,
@@ -155,7 +153,121 @@ def test_e2e_update_variation_quantity_from_list_view(
     dataset: dict[str, Any],
 ):
 
-    print(f"{os.linesep}Running E2E test to update variation quantity from list view...", end=" ")
+    print(f"{os.linesep}Running E2E test to add variations to cart from list view with button...", end=" ")
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    user_operations = UserOperations(graphql_client)
+    cart_operations = CartOperations(graphql_client)
+
+    with allure.step("Authenticate as regular user"):
+        dataset_user = dataset["users"][0]
+        auth.authenticate(dataset_user["userName"], config["USERS_PASSWORD"], page)
+        user = user_operations.get_me()
+
+    with allure.step("Navigate to Smart Watches category and switch to list view"):
+        category_page = CategoryPage(config, page, SMART_WATCHES_SEO_PATH)
+        category_page.navigate()
+
+        category_page.view_switcher.switch_category_view("list")
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            category_page.products_list_view,
+            "Products list view should be visible after switching to list view",
+        ).to_be_visible()
+
+    with allure.step(f"Find product card for SKU {PRODUCT_SKU} and expand variations"):
+        product_card = category_page.get_product_card_by_sku_list(PRODUCT_SKU)
+        assert product_card is not None, f"Product card with SKU '{PRODUCT_SKU}' not found in list view"
+
+        expect(
+            product_card.variations_button,
+            "Variations button should be visible on the product card in list view",
+        ).to_be_visible()
+
+        product_card.variations_button.click()
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            product_card.variants_wrapper,
+            "Variants wrapper should be visible after clicking the variations button",
+        ).to_be_visible()
+
+        expect(
+            product_card.variants_wrapper.locator("[data-test-id='line-item']").first,
+            "At least one variation line item should be visible",
+        ).to_be_visible()
+
+    try:
+        with allure.step(f"Add '{VARIATION_NAME_RED}' to cart"):
+            variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
+            assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
+
+            variation_red.add_to_cart_component.add_to_cart_text_button.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(
+                variation_red.count_in_cart_label,
+                f"Count in cart label should be visible for '{VARIATION_NAME_RED}'",
+            ).to_be_visible()
+            expect(
+                variation_red.count_in_cart_label,
+                f"Count in cart label should show '1' for '{VARIATION_NAME_RED}'",
+            ).to_have_text("1")
+
+        with allure.step(f"Add '{VARIATION_NAME_BLUE}' to cart"):
+            variation_blue = product_card.get_variation_line_item_by_name(VARIATION_NAME_BLUE)
+            assert variation_blue is not None, f"Variation line item '{VARIATION_NAME_BLUE}' not found"
+
+            variation_blue.add_to_cart_component.add_to_cart_text_button.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(
+                variation_blue.count_in_cart_label,
+                f"Count in cart label should be visible for '{VARIATION_NAME_BLUE}'",
+            ).to_be_visible()
+            expect(
+                variation_blue.count_in_cart_label,
+                f"Count in cart label should show '1' for '{VARIATION_NAME_BLUE}'",
+            ).to_have_text("1")
+
+        with allure.step("Verify cart badge shows 2 items"):
+            expect(
+                category_page.cart_badge,
+                "Cart badge should show '2' after adding two variations",
+            ).to_have_text("2")
+
+    finally:
+        with allure.step("Cleanup: remove cart"):
+            cart = cart_operations.get_cart(
+                store_id=config["STORE_ID"],
+                user_id=user["id"],
+                currency_code="USD",
+                culture_name="en-US",
+            )
+            if cart and cart.get("id"):
+                cart_operations.remove_cart(
+                    payload={
+                        "cartId": cart["id"],
+                        "userId": user["id"],
+                    }
+                )
+            auth.clear_token()
+
+
+@pytest.mark.e2e
+@pytest.mark.quantity_control("stepper")
+@allure.title("Update variation quantity in cart from category list view with stepper (E2E)")
+def test_e2e_update_variation_quantity_from_list_view_stepper(
+    config: Config,
+    auth: Auth,
+    graphql_client: GraphQLClient,
+    page: Page,
+    dataset: dict[str, Any],
+):
+
+    print(f"{os.linesep}Running E2E test to update variation quantity from list view with stepper...", end=" ")
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -201,32 +313,124 @@ def test_e2e_update_variation_quantity_from_list_view(
             variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
             assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
 
-            if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-                variation_red.add_to_cart_component.add_to_cart_text_button.click()
-            else:
-                variation_red.quantity_stepper_increment.click()
+            variation_red.quantity_stepper_increment.click()
             page.wait_for_load_state("networkidle")
 
             expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")
             expect(variation_red.count_in_cart_label, "Count in cart should show '1'").to_have_text("1")
 
         with allure.step(f"Increment '{VARIATION_NAME_RED}' quantity to 2"):
-            if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-                variation_red.add_to_cart_component.quantity_input.fill("2")
-                variation_red.add_to_cart_component.add_to_cart_text_button.click()
-            else:
-                variation_red.quantity_stepper_increment.click()
+            variation_red.quantity_stepper_increment.click()
             page.wait_for_load_state("networkidle")
 
             expect(variation_red.quantity_input, "Quantity input should show '2'").to_have_value("2")
             expect(variation_red.count_in_cart_label, "Count in cart should show '2'").to_have_text("2")
 
         with allure.step(f"Decrement '{VARIATION_NAME_RED}' quantity back to 1"):
-            if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-                variation_red.add_to_cart_component.quantity_input.fill("1")
-                variation_red.add_to_cart_component.add_to_cart_text_button.click()
-            else:
-                variation_red.quantity_stepper_decrement.click()
+            variation_red.quantity_stepper_decrement.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '1'").to_have_text("1")
+
+        with allure.step("Verify cart badge shows 1 item"):
+            expect(
+                category_page.cart_badge,
+                "Cart badge should show '1' after updating variation quantity",
+            ).to_have_text("1")
+
+    finally:
+        with allure.step("Cleanup: remove cart"):
+            cart = cart_operations.get_cart(
+                store_id=config["STORE_ID"],
+                user_id=user["id"],
+                currency_code="USD",
+                culture_name="en-US",
+            )
+            if cart and cart.get("id"):
+                cart_operations.remove_cart(
+                    payload={
+                        "cartId": cart["id"],
+                        "userId": user["id"],
+                    }
+                )
+            auth.clear_token()
+
+
+@pytest.mark.e2e
+@pytest.mark.quantity_control("button")
+@allure.title("Update variation quantity in cart from category list view with button (E2E)")
+def test_e2e_update_variation_quantity_from_list_view_button(
+    config: Config,
+    auth: Auth,
+    graphql_client: GraphQLClient,
+    page: Page,
+    dataset: dict[str, Any],
+):
+
+    print(f"{os.linesep}Running E2E test to update variation quantity from list view with button...", end=" ")
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    user_operations = UserOperations(graphql_client)
+    cart_operations = CartOperations(graphql_client)
+
+    with allure.step("Authenticate as regular user"):
+        dataset_user = dataset["users"][0]
+        auth.authenticate(dataset_user["userName"], config["USERS_PASSWORD"], page)
+        user = user_operations.get_me()
+
+    with allure.step("Navigate to Smart Watches category and switch to list view"):
+        category_page = CategoryPage(config, page, SMART_WATCHES_SEO_PATH)
+        category_page.navigate()
+
+        category_page.view_switcher.switch_category_view("list")
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            category_page.products_list_view,
+            "Products list view should be visible after switching to list view",
+        ).to_be_visible()
+
+    with allure.step(f"Find product card for SKU {PRODUCT_SKU} and expand variations"):
+        product_card = category_page.get_product_card_by_sku_list(PRODUCT_SKU)
+        assert product_card is not None, f"Product card with SKU '{PRODUCT_SKU}' not found in list view"
+
+        expect(
+            product_card.variations_button,
+            "Variations button should be visible on the product card in list view",
+        ).to_be_visible()
+
+        product_card.variations_button.click()
+        page.wait_for_load_state("networkidle")
+
+        expect(
+            product_card.variants_wrapper.locator("[data-test-id='line-item']").first,
+            "At least one variation line item should be visible",
+        ).to_be_visible()
+
+    try:
+        with allure.step(f"Add '{VARIATION_NAME_RED}' to cart (quantity 1)"):
+            variation_red = product_card.get_variation_line_item_by_name(VARIATION_NAME_RED)
+            assert variation_red is not None, f"Variation line item '{VARIATION_NAME_RED}' not found"
+
+            variation_red.add_to_cart_component.add_to_cart_text_button.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '1'").to_have_text("1")
+
+        with allure.step(f"Increment '{VARIATION_NAME_RED}' quantity to 2"):
+            variation_red.add_to_cart_component.quantity_input.fill("2")
+            variation_red.add_to_cart_component.add_to_cart_text_button.click()
+            page.wait_for_load_state("networkidle")
+
+            expect(variation_red.quantity_input, "Quantity input should show '2'").to_have_value("2")
+            expect(variation_red.count_in_cart_label, "Count in cart should show '2'").to_have_text("2")
+
+        with allure.step(f"Decrement '{VARIATION_NAME_RED}' quantity back to 1"):
+            variation_red.add_to_cart_component.quantity_input.fill("1")
+            variation_red.add_to_cart_component.add_to_cart_text_button.click()
             page.wait_for_load_state("networkidle")
 
             expect(variation_red.quantity_input, "Quantity input should show '1'").to_have_value("1")

--- a/tests_e2e/tests/test_e2e_category_add_to_cart_viewport.py
+++ b/tests_e2e/tests/test_e2e_category_add_to_cart_viewport.py
@@ -9,13 +9,14 @@ from tests_e2e.pages import CategoryPage
 
 
 @pytest.mark.e2e
-def test_e2e_category_add_to_cart_component_viewport(
+@pytest.mark.quantity_control("stepper")
+def test_e2e_category_add_to_cart_component_viewport_stepper(
     config: Config,
     page: Page,
     dataset: dict[str, Any],
 ):
     print(
-        f"{os.linesep}Running E2E test to check category add to cart component viewport...",
+        f"{os.linesep}Running E2E test to check category add to cart stepper component viewport...",
         end=" ",
     )
 
@@ -33,25 +34,47 @@ def test_e2e_category_add_to_cart_component_viewport(
 
     expect(product_card.element).to_be_visible(), "Product card is not visible"
 
-    if config["PRODUCT_QUANTITY_CONTROL"] == "stepper":
-        expect(
-            product_card.quantity_stepper_component.element
-        ).to_be_visible(), "Quantity stepper component is not visible"
+    expect(product_card.quantity_stepper_component.element).to_be_visible(), "Quantity stepper component is not visible"
 
-    if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-        expect(
-            product_card.add_to_cart_component.add_to_cart_text_button
-        ).to_be_visible(), "Add to cart text button is not visible"
-        expect(
-            product_card.add_to_cart_component.add_to_cart_icon_button
-        ).not_to_be_visible(), "Add to cart icon button is visible"
+
+@pytest.mark.e2e
+@pytest.mark.quantity_control("button")
+def test_e2e_category_add_to_cart_component_viewport_button(
+    config: Config,
+    page: Page,
+    dataset: dict[str, Any],
+):
+    print(
+        f"{os.linesep}Running E2E test to check category add to cart button component viewport...",
+        end=" ",
+    )
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    category = dataset["categories"][0]
+    product = dataset["products"][1]
+
+    category_page = CategoryPage(config, page, category["seoInfos"][0]["semanticUrl"])
+    category_page.navigate()
+
+    category_page.view_switcher.switch_category_view("grid")
+
+    product_card = category_page.get_product_card_by_sku_grid(product["code"])
+
+    expect(product_card.element).to_be_visible(), "Product card is not visible"
+
+    expect(
+        product_card.add_to_cart_component.add_to_cart_text_button
+    ).to_be_visible(), "Add to cart text button is not visible"
+    expect(
+        product_card.add_to_cart_component.add_to_cart_icon_button
+    ).not_to_be_visible(), "Add to cart icon button is visible"
 
     page.set_viewport_size({"width": 800, "height": 600})
 
-    if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-        expect(
-            product_card.add_to_cart_component.add_to_cart_text_button
-        ).not_to_be_visible(), "Add to cart text button is visible"
-        expect(
-            product_card.add_to_cart_component.add_to_cart_icon_button
-        ).to_be_visible(), "Add to cart icon button is not visible"
+    expect(
+        product_card.add_to_cart_component.add_to_cart_text_button
+    ).not_to_be_visible(), "Add to cart text button is visible"
+    expect(
+        product_card.add_to_cart_component.add_to_cart_icon_button
+    ).to_be_visible(), "Add to cart icon button is not visible"

--- a/tests_e2e/tests/test_e2e_category_page_add_product_to_cart.py
+++ b/tests_e2e/tests/test_e2e_category_page_add_product_to_cart.py
@@ -11,6 +11,7 @@ from tests_e2e.pages import CartPage, CategoryPage
 
 
 @pytest.mark.e2e
+@pytest.mark.quantity_control("button")
 def test_e2e_category_add_product_to_cart_with_add_to_cart_button(
     config: Config,
     auth: Auth,
@@ -18,8 +19,6 @@ def test_e2e_category_add_product_to_cart_with_add_to_cart_button(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["PRODUCT_QUANTITY_CONTROL"] == "stepper":
-        pytest.skip("Product quantity control is a stepper")
 
     print(
         f"{os.linesep}Running E2E test to add product to a cart from category page with add to cart button...",
@@ -79,6 +78,7 @@ def test_e2e_category_add_product_to_cart_with_add_to_cart_button(
 
 
 @pytest.mark.e2e
+@pytest.mark.quantity_control("stepper")
 def test_e2e_category_add_product_to_cart_with_quantity_stepper(
     config: Config,
     auth: Auth,
@@ -86,8 +86,6 @@ def test_e2e_category_add_product_to_cart_with_quantity_stepper(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["PRODUCT_QUANTITY_CONTROL"] == "button":
-        pytest.skip("Product quantity control is add to cart button")
 
     print(
         f"{os.linesep}Running E2E test to add product to cart from category page with quantity stepper...",

--- a/tests_e2e/tests/test_e2e_category_price_range_filter.py
+++ b/tests_e2e/tests/test_e2e_category_price_range_filter.py
@@ -9,13 +9,12 @@ from tests_e2e.pages import CategoryPage
 
 
 @pytest.mark.e2e
+@pytest.mark.range_filter("slider")
 def test_e2e_category_price_range_filter_slider(
     config: Config,
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["RANGE_FILTER_TYPE"] == "default":
-        pytest.skip("Range filter type is not supported for this test")
 
     print(
         f"{os.linesep}Running E2E test to check category price range filter slider...",
@@ -48,13 +47,12 @@ def test_e2e_category_price_range_filter_slider(
 
 
 @pytest.mark.e2e
+@pytest.mark.range_filter("default")
 def test_e2e_category_price_range_filter_default(
     config: Config,
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["RANGE_FILTER_TYPE"] == "slider":
-        pytest.skip("Range filter type is not supported for this test")
 
     print(
         f"{os.linesep}Running E2E test to check default category price range filter...",

--- a/tests_e2e/tests/test_e2e_change_cart_item.py
+++ b/tests_e2e/tests/test_e2e_change_cart_item.py
@@ -12,14 +12,15 @@ from tests_e2e.pages import CartPage, CategoryPage
 
 
 @pytest.mark.e2e
-def test_e2e_change_cart_item(
+@pytest.mark.quantity_control("stepper")
+def test_e2e_change_cart_item_stepper(
     config: Config,
     auth: Auth,
     graphql_client: GraphQLClient,
     dataset: dict[str, Any],
     page: Page,
 ):
-    print(f"{os.linesep}Running E2E test to change cart item...", end=" ")
+    print(f"{os.linesep}Running E2E test to change cart item with stepper...", end=" ")
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -44,17 +45,55 @@ def test_e2e_change_cart_item(
     cart_page.navigate()
 
     line_item = cart_page.get_line_item_by_sku(product["code"])
-    if config["PRODUCT_QUANTITY_CONTROL"] == "stepper":
-        line_item.quantity_stepper_component.increment_button.click()
-    elif config["PRODUCT_QUANTITY_CONTROL"] == "button":
-        line_item.add_to_cart_component.quantity_input.fill("3")
+    line_item.quantity_stepper_component.increment_button.click()
 
-    # requests_tracker.wait_for_all_requests()
+    expect(line_item.quantity_stepper_component.quantity_input).to_have_value("3")
 
-    if config["PRODUCT_QUANTITY_CONTROL"] == "stepper":
-        expect(line_item.quantity_stepper_component.quantity_input).to_have_value("3")
-    elif config["PRODUCT_QUANTITY_CONTROL"] == "button":
-        expect(line_item.add_to_cart_component.quantity_input).to_have_value("3")
+    cart_operations.remove_cart(
+        payload={
+            "cartId": cart["id"],
+            "userId": user["id"],
+        }
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.quantity_control("button")
+def test_e2e_change_cart_item_button(
+    config: Config,
+    auth: Auth,
+    graphql_client: GraphQLClient,
+    dataset: dict[str, Any],
+    page: Page,
+):
+    print(f"{os.linesep}Running E2E test to change cart item with button...", end=" ")
+
+    page.set_viewport_size({"width": 1920, "height": 1080})
+
+    product = dataset["products"][1]
+
+    user_operations = UserOperations(graphql_client)
+    cart_operations = CartOperations(graphql_client)
+
+    user = user_operations.get_me()
+    cart = cart_operations.add_item_to_cart(
+        payload={
+            "storeId": config["STORE_ID"],
+            "userId": user["id"],
+            "productId": product["code"],
+            "quantity": 2,
+        }
+    )
+
+    auth.set_local_storage_user_id(page, user["id"])
+
+    cart_page = CartPage(config, page)
+    cart_page.navigate()
+
+    line_item = cart_page.get_line_item_by_sku(product["code"])
+    line_item.add_to_cart_component.quantity_input.fill("3")
+
+    expect(line_item.add_to_cart_component.quantity_input).to_have_value("3")
 
     cart_operations.remove_cart(
         payload={

--- a/tests_e2e/tests/test_e2e_checkout_add_shipping_address.py
+++ b/tests_e2e/tests/test_e2e_checkout_add_shipping_address.py
@@ -12,6 +12,7 @@ from tests_e2e.pages import CartPage, CheckoutShippingPage
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_anonymous_single_page_checkout_add_shipping_address(
     config: Config,
     auth: Auth,
@@ -19,10 +20,6 @@ def test_e2e_anonymous_single_page_checkout_add_shipping_address(
     dataset: dict[str, Any],
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip(
-            "Checkout mode is a multi-step, skipping test for single-page checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to add a shipping address in anonymous single-page checkout...",
@@ -57,9 +54,7 @@ def test_e2e_anonymous_single_page_checkout_add_shipping_address(
 
     cart_page.shipping_details_section_component.address_selector_component.select_address_button.click()
 
-    edit_address_modal = EditAddressModalComponent(
-        page.locator("[data-test-id='edit-address-modal']")
-    )
+    edit_address_modal = EditAddressModalComponent(page.locator("[data-test-id='edit-address-modal']"))
 
     expect(edit_address_modal.element).to_be_visible()
 
@@ -95,16 +90,13 @@ def test_e2e_anonymous_single_page_checkout_add_shipping_address(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_anonymous_multi_step_checkout_add_shipping_address(
     config: Config,
     auth: Auth,
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to add a shipping address in anonymous multi-step checkout...",
@@ -137,9 +129,7 @@ def test_e2e_anonymous_multi_step_checkout_add_shipping_address(
 
     checkout_shipping_page.shipping_details_section_component.address_selector_component.select_address_button.click()
 
-    edit_address_modal = EditAddressModalComponent(
-        page.locator("[data-test-id='edit-address-modal']")
-    )
+    edit_address_modal = EditAddressModalComponent(page.locator("[data-test-id='edit-address-modal']"))
 
     expect(edit_address_modal.element).to_be_visible()
 

--- a/tests_e2e/tests/test_e2e_checkout_select_shipping_address.py
+++ b/tests_e2e/tests/test_e2e_checkout_select_shipping_address.py
@@ -14,6 +14,7 @@ from tests_e2e.pages import CartPage, CheckoutShippingPage
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_single_page_checkout_select_shipping_address(
     config: Config,
     dataset: dict[str, Any],
@@ -21,10 +22,6 @@ def test_e2e_single_page_checkout_select_shipping_address(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip(
-            "Checkout mode is a multi-step, skipping test for single-page checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to select a shipping address in single-page checkout...",
@@ -57,9 +54,7 @@ def test_e2e_single_page_checkout_select_shipping_address(
 
     cart_page.shipping_details_section_component.address_selector_component.select_address_button.click()
 
-    select_address_modal = SelectAddressModalComponent(
-        page.locator("[data-test-id='select-address-modal']")
-    )
+    select_address_modal = SelectAddressModalComponent(page.locator("[data-test-id='select-address-modal']"))
 
     expect(select_address_modal.element).to_be_visible()
     expect(select_address_modal.items[0]).to_be_visible()
@@ -87,6 +82,7 @@ def test_e2e_single_page_checkout_select_shipping_address(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_multi_step_checkout_select_shipping_address(
     config: Config,
     dataset: dict[str, Any],
@@ -94,10 +90,6 @@ def test_e2e_multi_step_checkout_select_shipping_address(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to select a shipping address in multi-step checkout...",
@@ -132,9 +124,7 @@ def test_e2e_multi_step_checkout_select_shipping_address(
 
     checkout_shipping_page.shipping_details_section_component.address_selector_component.select_address_button.click()
 
-    select_address_modal = SelectAddressModalComponent(
-        page.locator("[data-test-id='select-address-modal']")
-    )
+    select_address_modal = SelectAddressModalComponent(page.locator("[data-test-id='select-address-modal']"))
 
     expect(select_address_modal.element).to_be_visible()
     expect(select_address_modal.items[0]).to_be_visible()

--- a/tests_e2e/tests/test_e2e_checkout_switch_shipping_option.py
+++ b/tests_e2e/tests/test_e2e_checkout_switch_shipping_option.py
@@ -11,6 +11,7 @@ from tests_e2e.pages import CartPage, CheckoutShippingPage
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_checkout_multi_step_switch_shipping_option(
     config: Config,
     auth: Auth,
@@ -18,10 +19,6 @@ def test_e2e_checkout_multi_step_switch_shipping_option(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to switch shipping option in multi-step checkout...",
@@ -50,9 +47,7 @@ def test_e2e_checkout_multi_step_switch_shipping_option(
     checkout_shipping_page = CheckoutShippingPage(config, page)
     checkout_shipping_page.navigate()
 
-    expect(page).to_have_url(
-        checkout_shipping_page.url
-    ), "Checkout shipping page is not loaded"
+    expect(page).to_have_url(checkout_shipping_page.url), "Checkout shipping page is not loaded"
     expect(
         checkout_shipping_page.shipping_details_section_component.element
     ).to_be_visible(), "Shipping details section is not visible"
@@ -63,9 +58,7 @@ def test_e2e_checkout_multi_step_switch_shipping_option(
         checkout_shipping_page.shipping_details_section_component.shipping_delivery_option_switcher
     ).to_be_visible(), "Shipping delivery option switcher is not visible"
 
-    checkout_shipping_page.shipping_details_section_component.switch_delivery_option(
-        "pickup"
-    )
+    checkout_shipping_page.shipping_details_section_component.switch_delivery_option("pickup")
 
     expect(
         checkout_shipping_page.shipping_details_section_component.pickup_point_section
@@ -74,9 +67,7 @@ def test_e2e_checkout_multi_step_switch_shipping_option(
         checkout_shipping_page.shipping_details_section_component.shipping_method_selector
     ).not_to_be_visible(), "Shipping method selector is visible"
 
-    checkout_shipping_page.shipping_details_section_component.switch_delivery_option(
-        "shipping"
-    )
+    checkout_shipping_page.shipping_details_section_component.switch_delivery_option("shipping")
 
     expect(
         checkout_shipping_page.shipping_details_section_component.pickup_point_section
@@ -94,6 +85,7 @@ def test_e2e_checkout_multi_step_switch_shipping_option(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_checkout_single_page_switch_shipping_option(
     config: Config,
     auth: Auth,
@@ -101,10 +93,6 @@ def test_e2e_checkout_single_page_switch_shipping_option(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip(
-            "Checkout mode is a multi-step, skipping test for single-page checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to switch shipping option in single-page checkout...",

--- a/tests_e2e/tests/test_e2e_create_order.py
+++ b/tests_e2e/tests/test_e2e_create_order.py
@@ -20,6 +20,7 @@ from tests_e2e.pages import (
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_create_order_multi_step_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -27,8 +28,6 @@ def test_e2e_create_order_multi_step_checkout(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test for multi-step checkout")
 
     print(
         f"{os.linesep}Running E2E test to create order in multi-step checkout...",
@@ -113,6 +112,7 @@ def test_e2e_create_order_multi_step_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_create_order_single_page_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -120,8 +120,6 @@ def test_e2e_create_order_single_page_checkout(
     graphql_client: GraphQLClient,
     page: Page,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test for single-page checkout")
 
     print(
         f"{os.linesep}Running E2E test to create order in multi-step checkout...",

--- a/tests_e2e/tests/test_e2e_filter_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_filter_pickup_locations.py
@@ -14,6 +14,7 @@ from tests_e2e.pages import CartPage, CheckoutShippingPage
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_filter_pickup_locations_elements_single_page_checkout(
     config: Config,
     auth: Auth,
@@ -21,8 +22,6 @@ def test_e2e_filter_pickup_locations_elements_single_page_checkout(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to check filter pickup locations elements on pickup point selection modal in single-page checkout...",
@@ -84,6 +83,7 @@ def test_e2e_filter_pickup_locations_elements_single_page_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_filter_pickup_locations_country_region_keyword_found_single_page_checkout(
     config: Config,
     auth: Auth,
@@ -91,8 +91,6 @@ def test_e2e_filter_pickup_locations_country_region_keyword_found_single_page_ch
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region with search keyword with positive results in single-page checkout...",
@@ -159,6 +157,7 @@ def test_e2e_filter_pickup_locations_country_region_keyword_found_single_page_ch
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_filter_pickup_locations_country_region_city_keyword_found_single_page_checkout(
     config: Config,
     auth: Auth,
@@ -166,8 +165,6 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_found_single_pa
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region, city with search keyword with positive results in single-page checkout...",
@@ -238,6 +235,7 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_found_single_pa
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_single_page_checkout(
     config: Config,
     auth: Auth,
@@ -245,8 +243,6 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_singl
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region, city with search keyword with negative results in single-page checkout...",
@@ -317,6 +313,7 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_singl
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_filter_pickup_locations_remove_filters_single_page_checkout(
     config: Config,
     auth: Auth,
@@ -324,8 +321,6 @@ def test_e2e_filter_pickup_locations_remove_filters_single_page_checkout(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a multi-step, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to remove filters from pickup point selection modal in single-page checkout...",
@@ -406,6 +401,7 @@ def test_e2e_filter_pickup_locations_remove_filters_single_page_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_filter_pickup_locations_elements_multi_step_checkout(
     config: Config,
     auth: Auth,
@@ -413,8 +409,6 @@ def test_e2e_filter_pickup_locations_elements_multi_step_checkout(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to check filter pickup locations elements on pickup point selection modal in multi-step checkout...",
@@ -480,6 +474,7 @@ def test_e2e_filter_pickup_locations_elements_multi_step_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_filter_pickup_locations_country_region_keyword_found_multi_step_checkout(
     config: Config,
     auth: Auth,
@@ -487,8 +482,6 @@ def test_e2e_filter_pickup_locations_country_region_keyword_found_multi_step_che
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region with search keyword with positive results in multi-step checkout...",
@@ -557,6 +550,7 @@ def test_e2e_filter_pickup_locations_country_region_keyword_found_multi_step_che
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_filter_pickup_locations_country_region_city_keyword_found_multi_step_checkout(
     config: Config,
     auth: Auth,
@@ -564,8 +558,6 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_found_multi_ste
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region, city with search keyword with positive results in multi-step checkout...",
@@ -640,6 +632,7 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_found_multi_ste
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_multi_step_checkout(
     config: Config,
     auth: Auth,
@@ -647,8 +640,6 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_multi
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to filter pickup locations by country, region, city with search keyword with negative results in multi-step checkout...",
@@ -723,6 +714,7 @@ def test_e2e_filter_pickup_locations_country_region_city_keyword_not_found_multi
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_filter_pickup_locations_remove_filters_multi_step_checkout(
     config: Config,
     auth: Auth,
@@ -730,8 +722,6 @@ def test_e2e_filter_pickup_locations_remove_filters_multi_step_checkout(
     page: Page,
     dataset: dict[str, Any],
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a single-page, skipping test")
 
     print(
         f"{os.linesep}Running E2E test to remove filters from pickup point selection modal in multi-step checkout...",

--- a/tests_e2e/tests/test_e2e_proceed_to_checkout.py
+++ b/tests_e2e/tests/test_e2e_proceed_to_checkout.py
@@ -11,6 +11,7 @@ from tests_e2e.pages import CartPage, CategoryPage, CheckoutShippingPage, SignIn
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_proceed_to_multi_step_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -18,8 +19,6 @@ def test_e2e_proceed_to_multi_step_checkout(
     page: Page,
     auth: Auth,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip("Checkout mode is a multi-step")
 
     print(f"{os.linesep}Running E2E test to proceed to multi-step checkout...", end=" ")
 
@@ -52,9 +51,7 @@ def test_e2e_proceed_to_multi_step_checkout(
 
     checkout_page = CheckoutShippingPage(config, page)
 
-    expect(checkout_page.page).to_have_url(
-        checkout_page.url
-    ), "Checkout page is not loaded"
+    expect(checkout_page.page).to_have_url(checkout_page.url), "Checkout page is not loaded"
     expect(
         checkout_page.shipping_details_section_component.element
     ).to_be_visible(), "Shipping details section is not visible"
@@ -68,6 +65,7 @@ def test_e2e_proceed_to_multi_step_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_proceed_to_single_page_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -75,12 +73,8 @@ def test_e2e_proceed_to_single_page_checkout(
     page: Page,
     auth: Auth,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip("Checkout mode is a single-page")
 
-    print(
-        f"{os.linesep}Running E2E test to proceed to single-page checkout...", end=" "
-    )
+    print(f"{os.linesep}Running E2E test to proceed to single-page checkout...", end=" ")
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -113,9 +107,7 @@ def test_e2e_proceed_to_single_page_checkout(
     expect(
         cart_page.payment_details_section_component.element
     ).to_be_visible(), "Payment details section is not visible"
-    expect(
-        cart_page.place_order_button
-    ).to_be_visible(), "Place order button is not visible"
+    expect(cart_page.place_order_button).to_be_visible(), "Place order button is not visible"
 
     cart_operations.remove_cart(
         payload={

--- a/tests_e2e/tests/test_e2e_select_pickup_location.py
+++ b/tests_e2e/tests/test_e2e_select_pickup_location.py
@@ -12,8 +12,10 @@ from tests_e2e.components.select_bopis_map_modal_component import (
 )
 from tests_e2e.pages import CartPage, CheckoutShippingPage
 
+
 @pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 @allure.title("Select pickup location in single-page checkout (E2E)")
 def test_e2e_select_pickup_location_single_page_checkout(
     config: Config,
@@ -22,10 +24,6 @@ def test_e2e_select_pickup_location_single_page_checkout(
     page: Page,
     auth: Auth,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -53,52 +51,29 @@ def test_e2e_select_pickup_location_single_page_checkout(
         "[data-test-id='select-address-button']"
     ).click()
 
-    select_pickup_location_modal = SelectBopisMapModalComponent(
-        page.locator(".select-address-map-modal")
-    )
+    select_pickup_location_modal = SelectBopisMapModalComponent(page.locator(".select-address-map-modal"))
     page.wait_for_selector("gmp-advanced-marker")
 
-    expect(
-        select_pickup_location_modal.element
-    ).to_be_visible(), "Select address modal is not visible"
-    expect(
-        select_pickup_location_modal.pickup_locations_list
-    ).to_be_visible(), "Pickup locations list is not visible"
-    expect(
-        select_pickup_location_modal.map_element
-    ).to_be_visible(), "Map element is not visible"
+    expect(select_pickup_location_modal.element).to_be_visible(), "Select address modal is not visible"
+    expect(select_pickup_location_modal.pickup_locations_list).to_be_visible(), "Pickup locations list is not visible"
+    expect(select_pickup_location_modal.map_element).to_be_visible(), "Map element is not visible"
 
-    pickup_location_to_select = select_pickup_location_modal.get_location_by_name(
-        "Atlantic Terminal Mall"
-    )
-    pickup_location_map_marker = (
-        select_pickup_location_modal.get_map_marker_by_location_name(
-            "Atlantic Terminal Mall"
-        )
-    )
+    pickup_location_to_select = select_pickup_location_modal.get_location_by_name("Atlantic Terminal Mall")
+    pickup_location_map_marker = select_pickup_location_modal.get_map_marker_by_location_name("Atlantic Terminal Mall")
 
-    expect(
-        pickup_location_to_select.element
-    ).to_be_visible(), "Pickup location is not visible"
-    expect(
-        pickup_location_map_marker
-    ).to_be_visible(), "Pickup location map marker is not visible"
+    expect(pickup_location_to_select.element).to_be_visible(), "Pickup location is not visible"
+    expect(pickup_location_map_marker).to_be_visible(), "Pickup location map marker is not visible"
 
     pickup_location_to_select.element.click()
 
     expect(select_pickup_location_modal.save_button).to_be_enabled()
 
     assert pickup_location_to_select.is_selected, "Pickup location is not selected"
-    assert (
-        pickup_location_map_marker.locator("gmp-pin").get_attribute("background")
-        == "var(--color-success-500)"
-    )
+    assert pickup_location_map_marker.locator("gmp-pin").get_attribute("background") == "var(--color-success-500)"
 
     select_pickup_location_modal.save_button.click()
 
-    expect(
-        select_pickup_location_modal.element
-    ).not_to_be_visible(), "Select address modal is not closed"
+    expect(select_pickup_location_modal.element).not_to_be_visible(), "Select address modal is not closed"
     expect(
         cart_page.shipping_details_section_component.pickup_point_section.locator(
             "[data-test-id='selected-address-label']"
@@ -108,6 +83,7 @@ def test_e2e_select_pickup_location_single_page_checkout(
 
 @pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 @allure.title("Select pickup location in multi-step checkout (E2E)")
 def test_e2e_select_pickup_location_multi_step_checkout(
     config: Config,
@@ -116,10 +92,6 @@ def test_e2e_select_pickup_location_multi_step_checkout(
     auth: Auth,
     graphql_client: GraphQLClient,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip(
-            "Checkout mode is a multi-step, skipping test for single-page checkout"
-        )
 
     page.set_viewport_size({"width": 1920, "height": 1080})
 
@@ -147,52 +119,29 @@ def test_e2e_select_pickup_location_multi_step_checkout(
         "[data-test-id='select-address-button']"
     ).click()
 
-    select_pickup_location_modal = SelectBopisMapModalComponent(
-        page.locator(".select-address-map-modal")
-    )
+    select_pickup_location_modal = SelectBopisMapModalComponent(page.locator(".select-address-map-modal"))
     page.wait_for_selector("gmp-advanced-marker")
 
-    expect(
-        select_pickup_location_modal.element
-    ).to_be_visible(), "Select address modal is not visible"
-    expect(
-        select_pickup_location_modal.pickup_locations_list
-    ).to_be_visible(), "Pickup locations list is not visible"
-    expect(
-        select_pickup_location_modal.map_element
-    ).to_be_visible(), "Map element is not visible"
+    expect(select_pickup_location_modal.element).to_be_visible(), "Select address modal is not visible"
+    expect(select_pickup_location_modal.pickup_locations_list).to_be_visible(), "Pickup locations list is not visible"
+    expect(select_pickup_location_modal.map_element).to_be_visible(), "Map element is not visible"
 
-    pickup_location_to_select = select_pickup_location_modal.get_location_by_name(
-        "Atlantic Terminal Mall"
-    )
-    pickup_location_map_marker = (
-        select_pickup_location_modal.get_map_marker_by_location_name(
-            "Atlantic Terminal Mall"
-        )
-    )
+    pickup_location_to_select = select_pickup_location_modal.get_location_by_name("Atlantic Terminal Mall")
+    pickup_location_map_marker = select_pickup_location_modal.get_map_marker_by_location_name("Atlantic Terminal Mall")
 
-    expect(
-        pickup_location_to_select.element
-    ).to_be_visible(), "Pickup location is not visible"
-    expect(
-        pickup_location_map_marker
-    ).to_be_visible(), "Pickup location map marker is not visible"
+    expect(pickup_location_to_select.element).to_be_visible(), "Pickup location is not visible"
+    expect(pickup_location_map_marker).to_be_visible(), "Pickup location map marker is not visible"
 
     pickup_location_to_select.element.click()
 
     expect(select_pickup_location_modal.save_button).to_be_enabled()
 
     assert pickup_location_to_select.is_selected, "Pickup location is not selected"
-    assert (
-        pickup_location_map_marker.locator("gmp-pin").get_attribute("background")
-        == "var(--color-success-500)"
-    )
+    assert pickup_location_map_marker.locator("gmp-pin").get_attribute("background") == "var(--color-success-500)"
 
     select_pickup_location_modal.save_button.click()
 
-    expect(
-        select_pickup_location_modal.element
-    ).not_to_be_visible(), "Select address modal is not closed"
+    expect(select_pickup_location_modal.element).not_to_be_visible(), "Select address modal is not closed"
     expect(
         checkout_shipping_page.shipping_details_section_component.pickup_point_section.locator(
             "[data-test-id='selected-address-label']"

--- a/tests_e2e/tests/test_e2e_shipping_cost.py
+++ b/tests_e2e/tests/test_e2e_shipping_cost.py
@@ -11,6 +11,7 @@ from tests_e2e.pages import CartPage, CheckoutShippingPage
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("single-page")
 def test_e2e_shipping_cost_single_page_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -18,10 +19,6 @@ def test_e2e_shipping_cost_single_page_checkout(
     auth: Auth,
     graphql_client: GraphQLClient,
 ):
-    if config["CHECKOUT_MODE"] == "multi-step":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to calculate shipping cost in single-page checkout...",
@@ -56,14 +53,12 @@ def test_e2e_shipping_cost_single_page_checkout(
     ground_shipping_method = next(
         shipping_method
         for shipping_method in cart["availableShippingMethods"]
-        if shipping_method["code"] == "FixedRate"
-        and shipping_method["optionName"] == "Ground"
+        if shipping_method["code"] == "FixedRate" and shipping_method["optionName"] == "Ground"
     )
     air_shipping_method = next(
         shipping_method
         for shipping_method in cart["availableShippingMethods"]
-        if shipping_method["code"] == "FixedRate"
-        and shipping_method["optionName"] == "Air"
+        if shipping_method["code"] == "FixedRate" and shipping_method["optionName"] == "Air"
     )
     bopis_shipping_method = next(
         shipping_method
@@ -103,6 +98,7 @@ def test_e2e_shipping_cost_single_page_checkout(
 
 
 @pytest.mark.e2e
+@pytest.mark.checkout_mode("multi-step")
 def test_e2e_shipping_cost_multi_step_checkout(
     config: Config,
     dataset: dict[str, Any],
@@ -110,10 +106,6 @@ def test_e2e_shipping_cost_multi_step_checkout(
     auth: Auth,
     graphql_client: GraphQLClient,
 ):
-    if config["CHECKOUT_MODE"] == "single-page":
-        pytest.skip(
-            "Checkout mode is a single-page, skipping test for multi-step checkout"
-        )
 
     print(
         f"{os.linesep}Running E2E test to calculate shipping cost in multi-step checkout...",
@@ -145,14 +137,12 @@ def test_e2e_shipping_cost_multi_step_checkout(
     ground_shipping_method = next(
         shipping_method
         for shipping_method in cart["availableShippingMethods"]
-        if shipping_method["code"] == "FixedRate"
-        and shipping_method["optionName"] == "Ground"
+        if shipping_method["code"] == "FixedRate" and shipping_method["optionName"] == "Ground"
     )
     air_shipping_method = next(
         shipping_method
         for shipping_method in cart["availableShippingMethods"]
-        if shipping_method["code"] == "FixedRate"
-        and shipping_method["optionName"] == "Air"
+        if shipping_method["code"] == "FixedRate" and shipping_method["optionName"] == "Air"
     )
     bopis_shipping_method = next(
         shipping_method
@@ -165,23 +155,23 @@ def test_e2e_shipping_cost_multi_step_checkout(
         f"{ground_shipping_method['code']}_{ground_shipping_method['optionName']}"
     )
 
-    expect(
-        checkout_shipping_page.order_summary_component.cart_shipping_total_label
-    ).to_have_text(ground_shipping_method["price"]["formattedAmount"])
+    expect(checkout_shipping_page.order_summary_component.cart_shipping_total_label).to_have_text(
+        ground_shipping_method["price"]["formattedAmount"]
+    )
 
     checkout_shipping_page.shipping_details_section_component.select_shipping_method(
         f"{air_shipping_method['code']}_{air_shipping_method['optionName']}"
     )
 
-    expect(
-        checkout_shipping_page.order_summary_component.cart_shipping_total_label
-    ).to_have_text(air_shipping_method["price"]["formattedAmount"])
+    expect(checkout_shipping_page.order_summary_component.cart_shipping_total_label).to_have_text(
+        air_shipping_method["price"]["formattedAmount"]
+    )
 
     checkout_shipping_page.shipping_details_section_component.pickup_delivery_option_switcher.click()
 
-    expect(
-        checkout_shipping_page.order_summary_component.cart_shipping_total_label
-    ).to_have_text(bopis_shipping_method["price"]["formattedAmount"])
+    expect(checkout_shipping_page.order_summary_component.cart_shipping_total_label).to_have_text(
+        bopis_shipping_method["price"]["formattedAmount"]
+    )
 
     cart_operations.remove_cart(
         payload={


### PR DESCRIPTION
Replace inline pytest.skip() config checks in E2E tests with declarative markers (checkout_mode, quantity_control, range_filter) handled centrally in conftest.py pytest_runtest_setup hook.