### PR TITLE
feat(restapi): close Katalon ModuleMarketing coverage gaps

### DIFF
--- a/_refactored/tests/restapi/marketing/test_dynamic_content.py
+++ b/_refactored/tests/restapi/marketing/test_dynamic_content.py
@@ -256,6 +256,57 @@ def test_pub_delete(content_pub_ops: ContentPublicationOperations) -> None:
 
 @pytest.mark.restapi
 @allure.feature("Marketing / Content Publications (REST API)")
+@allure.title("Publication condition: add → update value → verify persisted via GET")
+def test_pub_condition_add_update(make_content_publication, content_pub_ops: ContentPublicationOperations) -> None:
+    pub = make_content_publication()
+
+    # Minimal dynamicExpression tree with one ConditionAgeIs leaf.
+    def condition_tree(age_value: int) -> dict:
+        return {
+            "all": True,
+            "not": False,
+            "id": "DynamicContentConditionTree",
+            "availableChildren": [],
+            "children": [
+                {
+                    "all": False,
+                    "not": False,
+                    "id": "BlockContentCondition",
+                    "availableChildren": [],
+                    "children": [
+                        {
+                            "id": "ConditionAgeIs",
+                            "compareCondition": "AtLeast",
+                            "value": age_value,
+                            "secondValue": 0,
+                            "availableChildren": [],
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+    with allure.step("PUT /contentpublications — attach ConditionAgeIs (value=21)"):
+        content_pub_ops.update(pub, dynamicExpression=condition_tree(21))
+
+    with allure.step("GET — verify initial value persisted"):
+        after_add = content_pub_ops.get_by_id(pub["id"])
+        leaf = after_add["dynamicExpression"]["children"][0]["children"][0]
+        assert leaf["id"] == "ConditionAgeIs"
+        assert leaf["value"] == 21
+
+    with allure.step("PUT /contentpublications — update value to 31"):
+        content_pub_ops.update(after_add, dynamicExpression=condition_tree(31))
+
+    with allure.step("GET — verify updated value persisted"):
+        after_update = content_pub_ops.get_by_id(pub["id"])
+        leaf2 = after_update["dynamicExpression"]["children"][0]["children"][0]
+        assert leaf2["value"] == 31, f"Expected 31, got {leaf2['value']}"
+
+
+@pytest.mark.restapi
+@allure.feature("Marketing / Content Publications (REST API)")
 @allure.title("Delete content publications in bulk")
 def test_pub_delete_bulk(content_pub_ops: ContentPublicationOperations) -> None:
     suffix = uuid.uuid4().hex[:6]

--- a/_refactored/tests/restapi/marketing/test_promotions.py
+++ b/_refactored/tests/restapi/marketing/test_promotions.py
@@ -109,6 +109,54 @@ def test_promo_delete(promo_ops: PromotionOperations) -> None:
 
 @pytest.mark.restapi
 @allure.feature("Marketing / Coupons (REST API)")
+@allure.title("Coupon full lifecycle: create → search → update → get-by-id → delete → verify gone")
+def test_coupon_create_update_delete(make_promotion, coupon_ops: CouponOperations) -> None:
+    promo = make_promotion()
+    code = f"QA-COUPON-{uuid.uuid4().hex[:6].upper()}"
+
+    with allure.step("POST /api/marketing/promotions/coupons/add — create coupon"):
+        coupon_ops.add([{"promotionId": promo["id"], "code": code, "maxUsesNumber": 15, "maxUsesPerUser": 10}])
+
+    with allure.step("POST /api/marketing/promotions/coupons/search — locate by code"):
+        search = coupon_ops.search(promotion_id=promo["id"])
+        results = search.get("results", []) if isinstance(search, dict) else search or []
+        found = next((c for c in results if c.get("code") == code), None)
+        assert found is not None, f"Coupon {code} not found after create"
+        assert found["maxUsesNumber"] == 15
+        assert found["maxUsesPerUser"] == 10
+        coupon_id = found["id"]
+
+    updated_code = f"{code}-UPD"
+    with allure.step("POST /coupons/add — update fields (same id, new code + counts)"):
+        coupon_ops.add(
+            [
+                {
+                    "id": coupon_id,
+                    "promotionId": promo["id"],
+                    "code": updated_code,
+                    "maxUsesNumber": 17,
+                    "maxUsesPerUser": 12,
+                }
+            ]
+        )
+
+    with allure.step(f"GET /coupons/{coupon_id} — verify update persisted"):
+        reloaded = coupon_ops.get_by_id(coupon_id)
+        assert reloaded["code"] == updated_code
+        assert reloaded["maxUsesNumber"] == 17
+        assert reloaded["maxUsesPerUser"] == 12
+
+    with allure.step(f"DELETE /coupons/delete?ids={coupon_id}"):
+        coupon_ops.delete(coupon_id)
+
+    with allure.step("POST /coupons/search — verify coupon is gone"):
+        post = coupon_ops.search(promotion_id=promo["id"])
+        post_results = post.get("results", []) if isinstance(post, dict) else post or []
+        assert not any(c.get("id") == coupon_id for c in post_results), "Deleted coupon still visible in search"
+
+
+@pytest.mark.restapi
+@allure.feature("Marketing / Coupons (REST API)")
 @allure.title("Create, search, and delete coupon")
 def test_coupon_create_search_delete(make_promotion, coupon_ops: CouponOperations) -> None:
     promo = make_promotion()


### PR DESCRIPTION
Existing marketing tests (32) already covered the canonical DynamicContent/* + PromoAndCoupons/* REAL Katalon scripts. Audit against the full module inventory surfaced two gaps:

1. DynamicContent/ContentPublications/contentPublicationConditionAddUpdateDelete — adds/updates a ConditionAgeIs leaf in dynamicExpression tree, verifies the value propagates via GET
2. PromoAndCoupons/promoCoupon_createUpdateDelete — was partially covered (create + search + delete); missing the update step (PromoCouponUpdate POSTs to /coupons/add with same id) and the get-by-id verify

Added:
- test_pub_condition_add_update — creates publication, attaches a minimal tree with ConditionAgeIs (value=21), updates to value=31, verifies both via GET
- test_coupon_create_update_delete — full lifecycle: create → search → update (code + maxUsesNumber + maxUsesPerUser via the same add endpoint with id) → get-by-id → delete → verify gone

Inventory:
- 21 REAL Katalon scripts mapped 1-to-1 to pytest tests
- Skipped duplicates: top-level contentItem/* and lowercase dynamicContent/* superseded by canonical DynamicContent/* tree; z_ snippets, _suiteTemplate files, TestDataCreation helpers, and z_DRAFT_* all skipped per skill rules

Local result: 34 passed in 20s.