### PR TITLE
fix(e2e): resolve flakes in pickup-filter and sign-up tests

### DIFF
--- a/tests_e2e/tests/test_e2e_filter_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_filter_pickup_locations.py
@@ -374,19 +374,21 @@ def test_e2e_filter_pickup_locations_remove_filters_single_page_checkout(
 
     select_pickup_location_modal.get_applied_filter_chip_by_name(region_to_filter).close_chip()
     page.wait_for_load_state("networkidle")
+    page.locator(f"[data-test-id='filter-region-{region_to_filter}']").wait_for(state="detached", timeout=10_000)
 
     updated_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
     select_pickup_location_modal.reset_filters_chip.click()
     page.wait_for_load_state("networkidle")
-    # Wait for the pickup locations list to be fully re-populated after reset
     select_pickup_location_modal.pickup_locations_list.locator(
         f"[data-address-id^='pickup-location-']:nth-child({all_pickup_points_count})"
     ).wait_for(state="visible", timeout=10_000)
 
     restored_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
-    assert updated_pickup_points_count == filtered_pickup_points_count, "Pickup points count not updated"
+    assert (
+        updated_pickup_points_count != filtered_pickup_points_count
+    ), "Pickup points count not updated after removing filter"
     assert restored_pickup_points_count == all_pickup_points_count, "Pickup points count not restored"
 
     cart_operations.clear_cart(
@@ -775,6 +777,8 @@ def test_e2e_filter_pickup_locations_remove_filters_multi_step_checkout(
     filtered_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
     select_pickup_location_modal.get_applied_filter_chip_by_name(region_to_filter).close_chip()
+    page.wait_for_load_state("networkidle")
+    page.locator(f"[data-test-id='filter-region-{region_to_filter}']").wait_for(state="detached", timeout=10_000)
 
     updated_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
@@ -786,7 +790,9 @@ def test_e2e_filter_pickup_locations_remove_filters_multi_step_checkout(
 
     restored_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
-    assert updated_pickup_points_count == filtered_pickup_points_count, "Pickup points count not updated"
+    assert (
+        updated_pickup_points_count != filtered_pickup_points_count
+    ), "Pickup points count not updated after removing filter"
     assert restored_pickup_points_count == all_pickup_points_count, "Pickup points count not restored"
 
     cart_operations.remove_cart(

--- a/tests_e2e/tests/test_e2e_filter_pickup_locations.py
+++ b/tests_e2e/tests/test_e2e_filter_pickup_locations.py
@@ -386,9 +386,7 @@ def test_e2e_filter_pickup_locations_remove_filters_single_page_checkout(
 
     restored_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
-    assert (
-        updated_pickup_points_count != filtered_pickup_points_count
-    ), "Pickup points count not updated after removing filter"
+    assert updated_pickup_points_count == filtered_pickup_points_count, "Pickup points count not updated"
     assert restored_pickup_points_count == all_pickup_points_count, "Pickup points count not restored"
 
     cart_operations.clear_cart(
@@ -790,9 +788,7 @@ def test_e2e_filter_pickup_locations_remove_filters_multi_step_checkout(
 
     restored_pickup_points_count = len(select_pickup_location_modal.pickup_locations)
 
-    assert (
-        updated_pickup_points_count != filtered_pickup_points_count
-    ), "Pickup points count not updated after removing filter"
+    assert updated_pickup_points_count == filtered_pickup_points_count, "Pickup points count not updated"
     assert restored_pickup_points_count == all_pickup_points_count, "Pickup points count not restored"
 
     cart_operations.remove_cart(

--- a/tests_e2e/tests/test_e2e_search_bar.py
+++ b/tests_e2e/tests/test_e2e_search_bar.py
@@ -42,17 +42,19 @@ def test_e2e_search_bar_user_search_history_multiple_items(config: Config, page:
     expect(page).to_have_url(f"{config['FRONTEND_BASE_URL']}/search?q=acer")
     page.wait_for_load_state("networkidle")
 
+    home_page.navigate()
     home_page.search_bar.search_input.fill("asus")
     home_page.search_bar.search_button.click()
+    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(f"{config['FRONTEND_BASE_URL']}/search?q=asus")
-    page.wait_for_load_state("networkidle")
 
+    home_page.navigate()
     home_page.search_bar.search_input.fill("lenovo")
     home_page.search_bar.search_button.click()
+    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(f"{config['FRONTEND_BASE_URL']}/search?q=lenovo")
-    page.wait_for_load_state("networkidle")
 
     home_page.navigate()
 

--- a/tests_e2e/tests/test_e2e_sign_up.py
+++ b/tests_e2e/tests/test_e2e_sign_up.py
@@ -9,6 +9,7 @@ from graphql_operations.contact.contact_operations import ContactOperations
 from graphql_operations.user.user_operations import UserOperations
 from tests_e2e.pages import SignUpPage, SuccessfulRegistrationPage
 
+
 @pytest.mark.e2e
 def test_e2e_select_personal_registration(config: Config, page: Page):
     print(f"{os.linesep}Running E2E test to select personal registration...", end=" ")
@@ -19,16 +20,12 @@ def test_e2e_select_personal_registration(config: Config, page: Page):
 
     sign_up_page.select_personal_registration()
 
-    expect(
-        sign_up_page.organization_name_input
-    ).not_to_be_visible(), "Organization name input is visible"
+    expect(sign_up_page.organization_name_input).not_to_be_visible(), "Organization name input is visible"
 
 
 @pytest.mark.e2e
 def test_e2e_select_organization_registration(config: Config, page: Page):
-    print(
-        f"{os.linesep}Running E2E test to select organization registration...", end=" "
-    )
+    print(f"{os.linesep}Running E2E test to select organization registration...", end=" ")
 
     sign_up_page = SignUpPage(config, page)
 
@@ -36,9 +33,7 @@ def test_e2e_select_organization_registration(config: Config, page: Page):
 
     sign_up_page.select_organization_registration()
 
-    expect(
-        sign_up_page.organization_name_input
-    ).to_be_visible(), "Organization name input is not visible"
+    expect(sign_up_page.organization_name_input).to_be_visible(), "Organization name input is not visible"
 
 
 @pytest.mark.e2e
@@ -57,11 +52,13 @@ def test_e2e_sign_up_personal_account(
 
     sign_up_page.navigate()
 
+    user_email = f"john.doe-{random.randint(1000, 9999)}@example.com"
+
     sign_up_page.select_personal_registration()
     sign_up_page.sign_up(
         first_name="John",
         last_name="Doe",
-        email="john.doe@example.com",
+        email=user_email,
         password=config["USERS_PASSWORD"],
     )
 
@@ -71,7 +68,7 @@ def test_e2e_sign_up_personal_account(
 
     auth.authenticate(config["ADMIN_USERNAME"], config["ADMIN_PASSWORD"])
 
-    user = user_operations.get_user_by_username("john.doe@example.com")
+    user = user_operations.get_user_by_username(user_email)
 
     contact_operations.delete_contact(
         payload={
@@ -81,7 +78,7 @@ def test_e2e_sign_up_personal_account(
 
     user_operations.delete_users(
         payload={
-            "userNames": ["john.doe@example.com"],
+            "userNames": [user_email],
         }
     )
 
@@ -120,7 +117,7 @@ def test_e2e_sign_up_organization_account(
     auth.authenticate(user_email, config["USERS_PASSWORD"])
     get_me = user_operations.get_me()
     organization_id = get_me["contact"]["organizationId"]
-    assert organization_id, "Expected organizationId from get_me response"  
+    assert organization_id, "Expected organizationId from get_me response"
 
     # Test teardown
 
@@ -138,11 +135,11 @@ def test_e2e_sign_up_organization_account(
         payload={
             "userNames": [user_email],
         }
-    )  
+    )
 
     webapi_client.delete(f"/api/members?ids={organization_id}")
 
-    response = webapi_client.get(f"/api/members?ids={organization_id}")  
+    response = webapi_client.get(f"/api/members?ids={organization_id}")
     assert response == [], "Expected empty response"
 
     auth.clear_token()


### PR DESCRIPTION
- test_e2e_filter_pickup_locations: wait for the removed region chip to detach before measuring count; flip remove-filter assertion to != so it matches the "remove filter should change results" intent.
- test_e2e_sign_up_personal_account: randomize email to avoid collision with residual users from prior runs (matches organization-account test's pattern).