### PR TITLE
VCST-4958: Add a new worflow for auto-tests

### DIFF
--- a/.github/workflows/auto-tests.yml
+++ b/.github/workflows/auto-tests.yml
@@ -1,0 +1,35 @@
+name: Auto Tests Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      frontendZipUrl:
+        description: 'Frontend zip url'
+        required: true
+        type: string
+        default: 'latest'
+      testSuites:
+        description: 'Test suites to run'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all
+          - graphql
+          - restapi
+          - e2e
+
+jobs:
+  e2e-tests:
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    with:
+      installModules: 'false'
+      installCustomModule: 'false'
+      vctestingRepoBranch: 'vcst-4773' #'${{ github.ref_name }}'
+      frontendZipUrl: '${{ inputs.frontendZipUrl }}'
+      customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/backend-packages.json'
+      testSuites: ${{ inputs.testSuites == 'all' && 'graphql,restapi,e2e' || inputs.testSuites }}
+    secrets:
+      envPAT: ${{ secrets.REPO_TOKEN }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }} #
+      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}

--- a/.github/workflows/auto-tests.yml
+++ b/.github/workflows/auto-tests.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      vctestingRepoBranch: 'vcst-4773' #'${{ github.ref_name }}'
+      vctestingRepoBranch: '${{ github.ref_name }}'
       frontendZipUrl: '${{ inputs.frontendZipUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/backend-packages.json'
       testSuites: ${{ inputs.testSuites == 'all' && 'graphql,restapi,e2e' || inputs.testSuites }}

--- a/.github/workflows/e2e-tests-docker.yml
+++ b/.github/workflows/e2e-tests-docker.yml
@@ -1,4 +1,4 @@
-name: Auto Tests Docker
+name: E2E Tests Docker
 
 on:
   workflow_dispatch:
@@ -8,28 +8,18 @@ on:
         required: true
         type: string
         default: 'latest'
-      testSuites:
-        description: 'Test suites to run'
-        required: true
-        type: choice
-        default: 'all'
-        options:
-          - all
-          - graphql
-          - restapi
-          - e2e
 
 jobs:
   e2e-tests:
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      vctestingRepoBranch: 'vcst-4773' #'${{ github.ref_name }}'
+      runTests: 'true'
+      vctestingRepoBranch: '${{ github.ref_name }}'
       frontendZipUrl: '${{ inputs.frontendZipUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/backend-packages.json'
-      testSuites: ${{ inputs.testSuites == 'all' && 'graphql,restapi,e2e' || inputs.testSuites }}
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }} #
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}

--- a/.github/workflows/e2e-tests-docker.yml
+++ b/.github/workflows/e2e-tests-docker.yml
@@ -1,4 +1,4 @@
-name: E2E Tests Docker
+name: Auto Tests Docker
 
 on:
   workflow_dispatch:
@@ -8,18 +8,28 @@ on:
         required: true
         type: string
         default: 'latest'
+      testSuites:
+        description: 'Test suites to run'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all
+          - graphql
+          - restapi
+          - e2e
 
 jobs:
   e2e-tests:
-    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      runTests: 'true'
-      vctestingRepoBranch: '${{ github.ref_name }}'
+      vctestingRepoBranch: 'vcst-4773' #'${{ github.ref_name }}'
       frontendZipUrl: '${{ inputs.frontendZipUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ github.ref_name }}/backend-packages.json'
+      testSuites: ${{ inputs.testSuites == 'all' && 'graphql,restapi,e2e' || inputs.testSuites }}
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }} #
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new manually triggered GitHub Actions workflow that delegates to an existing reusable pytest workflow and only affects CI execution.
> 
> **Overview**
> Adds a new `workflow_dispatch` GitHub Actions workflow (`.github/workflows/auto-tests.yml`) to run auto-tests in Docker using the shared `VirtoCommerce/.github` `pytest-tests.yml` reusable workflow.
> 
> The workflow accepts `frontendZipUrl` and a `testSuites` selector (including an `all` option that expands to `graphql,restapi,e2e`), and wires required secrets plus a `backend-packages.json` URL based on the current branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdf74113beb3aa8bbb14fba6b64e8209af9d55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->