### PR TITLE
fix: remove Component.wait_for_results networkidle pattern (C8)

### DIFF
--- a/.claude/skills/create-ui-layer/SKILL.md
+++ b/.claude/skills/create-ui-layer/SKILL.md
@@ -107,10 +107,9 @@ class Component:
     @property
     def root(self) -> Locator:
         return self._root
-
-    def wait_for_results(self) -> None:
-        self._root.page.wait_for_load_state("networkidle")
 ```
+
+Do not add a `wait_for_results()` (or any `wait_for_load_state("networkidle")`) helper. `networkidle` is discouraged by Playwright and hangs on apps with WebSocket/polling traffic. Tests should wait via explicit `expect(locator).to_be_visible()` / `to_have_count(N)` assertions on the specific element they care about — Playwright's auto-wait covers the legitimate cases.
 
 ## Concrete Component Pattern
 
@@ -222,6 +221,6 @@ from page_objects.components.product_card import ProductCard
 7. Use `data-test-id` attributes — prefer over CSS selectors or XPath
 8. `navigate()` uses `wait_until="load"` (not `networkidle`)
 9. No assertions or test logic in page objects/components
-10. No `time.sleep()` — components can use `wait_for_results()` when needed
+10. No `time.sleep()` and no `networkidle` waits — wait via explicit `expect()` assertions on specific locators
 11. Add new pages/components to `__init__.py` exports
 12. Type annotations on all properties: `-> Locator`, `-> str | None`, `-> ChildComponent`

--- a/page_objects/components/component.py
+++ b/page_objects/components/component.py
@@ -8,6 +8,3 @@ class Component:
     @property
     def root(self) -> Locator:
         return self._root
-
-    def wait_for_results(self) -> None:
-        self._root.page.wait_for_load_state("networkidle")

--- a/tests/e2e/test_account_menu_organizations.py
+++ b/tests/e2e/test_account_menu_organizations.py
@@ -30,23 +30,15 @@ def test_account_menu_organizations_change(
 
     expect(home_page.top_header.account_button.customer_name_label).to_be_visible()
     expect(home_page.top_header.account_button.organization_name_label).to_be_visible()
-    expect(home_page.top_header.account_button.organization_name_label).to_have_text(
-        _ORIGINAL_ORGANIZATION_NAME
-    )
+    expect(home_page.top_header.account_button.organization_name_label).to_have_text(_ORIGINAL_ORGANIZATION_NAME)
 
     home_page.top_header.account_button.root.click()
     expect(home_page.top_header.account_menu.root).to_be_visible()
 
-    home_page.top_header.account_menu.select_organization(
-        name=_TARGET_ORGANIZATION_NAME
-    )
-    expect(home_page.top_header.account_button.organization_name_label).to_have_text(
-        _TARGET_ORGANIZATION_NAME
-    )
+    home_page.top_header.account_menu.select_organization(name=_TARGET_ORGANIZATION_NAME)
+    expect(home_page.top_header.account_button.organization_name_label).to_have_text(_TARGET_ORGANIZATION_NAME)
     home_page.top_header.account_button.root.click()
-    home_page.top_header.account_menu.select_organization(
-        name=_ORIGINAL_ORGANIZATION_NAME
-    )
+    home_page.top_header.account_menu.select_organization(name=_ORIGINAL_ORGANIZATION_NAME)
 
 
 @pytest.mark.e2e
@@ -62,9 +54,7 @@ def test_account_menu_organizations_search(
     home_page.top_header.account_button.root.click()
     expect(home_page.top_header.account_menu.root).to_be_visible()
     expect(home_page.top_header.account_menu.search_organizations_input).to_be_visible()
-    expect(
-        home_page.top_header.account_menu.search_organizations_button
-    ).to_be_visible()
+    expect(home_page.top_header.account_menu.search_organizations_button).to_be_visible()
 
     part_of_org_name = "ACME Store"
     home_page.top_header.account_menu.search_organizations_input.fill(part_of_org_name)
@@ -73,12 +63,8 @@ def test_account_menu_organizations_search(
     expect(home_page.top_header.account_menu.organizations_list.first).to_be_visible()
 
     orgs = home_page.top_header.account_menu.organizations_list
-    names = [
-        orgs.nth(i).get_attribute("data-organization-name") for i in range(orgs.count())
-    ]
-    assert (
-        len(names) > 1
-    ), "No search results found (only the pinned current organization)"
+    names = [orgs.nth(i).get_attribute("data-organization-name") for i in range(orgs.count())]
+    assert len(names) > 1, "No search results found (only the pinned current organization)"
     assert all(
         part_of_org_name.lower() in name.lower() for name in names if name
     ), f"Not all organizations contain '{part_of_org_name}': {names}"
@@ -97,9 +83,7 @@ def test_account_menu_organizations_search_not_found(
     home_page.top_header.account_button.root.click()
     expect(home_page.top_header.account_menu.root).to_be_visible()
     expect(home_page.top_header.account_menu.search_organizations_input).to_be_visible()
-    expect(
-        home_page.top_header.account_menu.search_organizations_button
-    ).to_be_visible()
+    expect(home_page.top_header.account_menu.search_organizations_button).to_be_visible()
 
     home_page.top_header.account_menu.search_organizations_input.fill("NonExistentOrg")
     home_page.top_header.account_menu.search_organizations_button.click()
@@ -123,22 +107,15 @@ def test_account_menu_organizations_search_special_characters(
     home_page.top_header.account_button.root.click()
     expect(home_page.top_header.account_menu.root).to_be_visible()
     expect(home_page.top_header.account_menu.search_organizations_input).to_be_visible()
-    expect(
-        home_page.top_header.account_menu.search_organizations_button
-    ).to_be_visible()
+    expect(home_page.top_header.account_menu.search_organizations_button).to_be_visible()
 
     home_page.top_header.account_menu.search_organizations_input.fill(search_term)
     home_page.top_header.account_menu.search_organizations_button.click()
-    home_page.top_header.account_menu.wait_for_results()
 
     orgs = home_page.top_header.account_menu.organizations_list
     expect(orgs.first).to_be_visible()
-    names = [
-        orgs.nth(i).get_attribute("data-organization-name") for i in range(orgs.count())
-    ]
-    assert (
-        len(names) > 1
-    ), "No search results found (only the pinned current organization)"
+    names = [orgs.nth(i).get_attribute("data-organization-name") for i in range(orgs.count())]
+    assert len(names) > 1, "No search results found (only the pinned current organization)"
     assert any(
         search_term.strip().lower() in name.lower() for name in names if name
     ), f"Expected at least one organization to contain '{search_term.strip()}', got {names}"

--- a/tests/e2e/test_cart_save_for_later.py
+++ b/tests/e2e/test_cart_save_for_later.py
@@ -22,12 +22,9 @@ def test_cart_save_for_later(global_settings: GlobalSettings, page: Page) -> Non
     expect(line_item.save_for_later_desktop_button).to_be_visible()
 
     line_item.save_for_later_desktop_button.click()
-    line_item.wait_for_results()
     expect(cart_page.line_items).to_have_count(0)
 
-    account_saved_for_later_page = AccountSavedForLaterPage(
-        global_settings=global_settings, page=page
-    )
+    account_saved_for_later_page = AccountSavedForLaterPage(global_settings=global_settings, page=page)
     account_saved_for_later_page.navigate()
     expect(account_saved_for_later_page.line_items).to_have_count(1)
 
@@ -36,9 +33,7 @@ def test_cart_save_for_later(global_settings: GlobalSettings, page: Page) -> Non
 
     saved_item.remove_button.click()
 
-    remove_item_modal = RemoveShoppingListItemModal(
-        root=page.locator("[data-test-id='delete-wishlist-product-modal']")
-    )
+    remove_item_modal = RemoveShoppingListItemModal(root=page.locator("[data-test-id='delete-wishlist-product-modal']"))
     expect(remove_item_modal.root).to_be_visible()
 
     remove_item_modal.delete_button.click()

--- a/tests/e2e/test_checkout_pickup_locations.py
+++ b/tests/e2e/test_checkout_pickup_locations.py
@@ -18,36 +18,26 @@ _FAKE_SEARCH_KEYWORD = "NonExistentLocation12345"
 @pytest.mark.skip
 @pytest.mark.with_cart([(_PRODUCT_ID, _QUANTITY)])
 @pytest.mark.checkout_mode("single-page")
-def test_checkout_pickup_locations_country_filter_single_page(
-    global_settings: GlobalSettings, page: Page
-) -> None:
+def test_checkout_pickup_locations_country_filter_single_page(global_settings: GlobalSettings, page: Page) -> None:
     cart_page = CartPage(global_settings=global_settings, page=page)
     cart_page.navigate()
 
     cart_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        cart_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(cart_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     cart_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     cart_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
     matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY)
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country filter"
+    assert len(matched) > 0, "No pickup location cards found matching the country filter"
 
 
 @pytest.mark.e2e
@@ -61,38 +51,26 @@ def test_checkout_pickup_locations_country_region_filter_single_page(
     cart_page.navigate()
 
     cart_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        cart_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(cart_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     cart_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     cart_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     cart_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region filter"
 
 
 @pytest.mark.e2e
@@ -106,29 +84,21 @@ def test_checkout_pickup_locations_country_region_city_filter_single_page(
     cart_page.navigate()
 
     cart_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        cart_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(cart_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     cart_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     cart_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     cart_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -136,13 +106,9 @@ def test_checkout_pickup_locations_country_region_city_filter_single_page(
     city_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_CITY)
     expect(city_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT, city=_CITY
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region/city filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT, city=_CITY)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region/city filter"
 
 
 @pytest.mark.e2e
@@ -156,29 +122,21 @@ def test_checkout_pickup_locations_country_region_city_keyword_filter_single_pag
     cart_page.navigate()
 
     cart_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        cart_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(cart_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     cart_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     cart_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     cart_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -189,13 +147,9 @@ def test_checkout_pickup_locations_country_region_city_keyword_filter_single_pag
     pickup_locations_modal.search_keyword_input.fill(_SEARCH_KEYWORD)
     pickup_locations_modal.search_button.click()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT, city=_CITY
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region/city/keyword filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT, city=_CITY)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region/city/keyword filter"
 
 
 @pytest.mark.e2e
@@ -209,29 +163,21 @@ def test_checkout_pickup_locations_fake_keyword_returns_no_cards_single_page(
     cart_page.navigate()
 
     cart_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        cart_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(cart_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     cart_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     cart_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     cart_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -242,7 +188,6 @@ def test_checkout_pickup_locations_fake_keyword_returns_no_cards_single_page(
     pickup_locations_modal.search_keyword_input.fill(_FAKE_SEARCH_KEYWORD)
     pickup_locations_modal.search_button.click()
 
-    pickup_locations_modal.wait_for_results()
     expect(pickup_locations_modal.pickup_location_cards).to_have_count(0)
 
 
@@ -250,38 +195,28 @@ def test_checkout_pickup_locations_fake_keyword_returns_no_cards_single_page(
 @pytest.mark.skip
 @pytest.mark.with_cart([(_PRODUCT_ID, _QUANTITY)])
 @pytest.mark.checkout_mode("multi-step")
-def test_checkout_pickup_locations_country_filter_multi_step(
-    global_settings: GlobalSettings, page: Page
-) -> None:
+def test_checkout_pickup_locations_country_filter_multi_step(global_settings: GlobalSettings, page: Page) -> None:
     cart_page = CartPage(global_settings=global_settings, page=page)
     cart_page.navigate()
     cart_page.checkout_button.click()
 
     shipping_page = CheckoutShippingPage(global_settings=global_settings, page=page)
     shipping_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        shipping_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(shipping_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     shipping_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     shipping_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
     matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY)
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country filter"
+    assert len(matched) > 0, "No pickup location cards found matching the country filter"
 
 
 @pytest.mark.e2e
@@ -297,38 +232,26 @@ def test_checkout_pickup_locations_country_region_filter_multi_step(
 
     shipping_page = CheckoutShippingPage(global_settings=global_settings, page=page)
     shipping_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        shipping_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(shipping_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     shipping_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     shipping_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     shipping_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region filter"
 
 
 @pytest.mark.e2e
@@ -344,29 +267,21 @@ def test_checkout_pickup_locations_country_region_city_filter_multi_step(
 
     shipping_page = CheckoutShippingPage(global_settings=global_settings, page=page)
     shipping_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        shipping_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(shipping_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     shipping_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     shipping_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     shipping_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -374,13 +289,9 @@ def test_checkout_pickup_locations_country_region_city_filter_multi_step(
     city_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_CITY)
     expect(city_chip.root).to_be_visible()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT, city=_CITY
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region/city filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT, city=_CITY)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region/city filter"
 
 
 @pytest.mark.e2e
@@ -396,29 +307,21 @@ def test_checkout_pickup_locations_country_region_city_keyword_filter_multi_step
 
     shipping_page = CheckoutShippingPage(global_settings=global_settings, page=page)
     shipping_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        shipping_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(shipping_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     shipping_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     shipping_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     shipping_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -429,13 +332,9 @@ def test_checkout_pickup_locations_country_region_city_keyword_filter_multi_step
     pickup_locations_modal.search_keyword_input.fill(_SEARCH_KEYWORD)
     pickup_locations_modal.search_button.click()
 
-    pickup_locations_modal.wait_for_results()
-    matched = pickup_locations_modal.find_pickup_location_cards(
-        country=_COUNTRY, region=_REGION_SHORT, city=_CITY
-    )
-    assert (
-        len(matched) > 0
-    ), "No pickup location cards found matching the country/region/city/keyword filter"
+    expect(pickup_locations_modal.pickup_location_cards.first).to_be_visible()
+    matched = pickup_locations_modal.find_pickup_location_cards(country=_COUNTRY, region=_REGION_SHORT, city=_CITY)
+    assert len(matched) > 0, "No pickup location cards found matching the country/region/city/keyword filter"
 
 
 @pytest.mark.e2e
@@ -451,29 +350,21 @@ def test_checkout_pickup_locations_fake_keyword_returns_no_cards_multi_step(
 
     shipping_page = CheckoutShippingPage(global_settings=global_settings, page=page)
     shipping_page.shipping_details_section.pickup_switcher.click()
-    expect(
-        shipping_page.shipping_details_section.pickup_location_section.root
-    ).to_be_visible()
+    expect(shipping_page.shipping_details_section.pickup_location_section.root).to_be_visible()
 
     shipping_page.shipping_details_section.pickup_location_section.select_address_button.click()
 
-    pickup_locations_modal = PickupLocationsModal(
-        root=page.locator("[data-test-id='pickup-locations-modal']")
-    )
+    pickup_locations_modal = PickupLocationsModal(root=page.locator("[data-test-id='pickup-locations-modal']"))
     expect(pickup_locations_modal.root).to_be_visible()
 
     pickup_locations_modal.country_filter_selector.select_item_by_name(name=_COUNTRY)
     shipping_page.click_outside()
-    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_COUNTRY
-    )
+    country_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_COUNTRY)
     expect(country_chip.root).to_be_visible()
 
     pickup_locations_modal.region_filter_selector.select_item_by_name(name=_REGION_FULL)
     shipping_page.click_outside()
-    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(
-        name=_REGION_FULL
-    )
+    region_chip = pickup_locations_modal.find_applied_filter_chip_by_name(name=_REGION_FULL)
     expect(region_chip.root).to_be_visible()
 
     pickup_locations_modal.city_filter_selector.select_item_by_name(name=_CITY)
@@ -484,5 +375,4 @@ def test_checkout_pickup_locations_fake_keyword_returns_no_cards_multi_step(
     pickup_locations_modal.search_keyword_input.fill(_FAKE_SEARCH_KEYWORD)
     pickup_locations_modal.search_button.click()
 
-    pickup_locations_modal.wait_for_results()
     expect(pickup_locations_modal.pickup_location_cards).to_have_count(0)


### PR DESCRIPTION
Playwright documents `networkidle` as DISCOURAGED — it hangs on apps with WebSocket/polling traffic. Project memory and the create-ui-layer SKILL already said "use wait_until=load, not networkidle", but the Component base class advertised the discouraged helper anyway.

- Delete `Component.wait_for_results()` from page_objects/components/component.py
- Replace 13 active call sites across 3 e2e test files with explicit Playwright assertions:
  - 9 positive cases (followed by `find_pickup_location_cards(...)` which snapshots via `.all()`) → `expect(...pickup_location_cards.first).to_be_visible()`
  - 4 cases where the next line was already an auto-waiting `expect(...)` → just delete
- Update .claude/skills/create-ui-layer/SKILL.md to remove the wait_for_results sample and explicitly say "no networkidle, wait via expect() on specific locators". Prevents the next UI-layer generation from reintroducing the pattern.