### PR TITLE
feat(restapi): add Pydantic models for top REST responses (C3) — Cata…

### DIFF
--- a/restapi/operations/catalog_operations.py
+++ b/restapi/operations/catalog_operations.py
@@ -4,23 +4,27 @@ from typing import Any
 
 from restapi.constants import CATALOG_TEMPLATE
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Catalog
 
 
 class CatalogOperations(RestBaseOperations):
     PATH = "/api/catalog/catalogs"
 
-    def create(self, *, name: str, **overrides: Any) -> dict:
+    def create(self, *, name: str, **overrides: Any) -> Catalog:
         payload = {**CATALOG_TEMPLATE, "name": name, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Catalog.model_validate(response)
 
-    def update(self, catalog: dict, **overrides: Any) -> dict:
+    def update(self, catalog: Catalog, **overrides: Any) -> Catalog:
+        existing = catalog.model_dump(by_alias=True, exclude_none=True)
         payload = {
             **CATALOG_TEMPLATE,
-            **catalog,
-            "properties": catalog.get("properties") or [],
+            **existing,
+            "properties": existing.get("properties") or [],
             **overrides,
         }
-        return self._client.put(self._url(self.PATH), json=payload)
+        response = self._client.put(self._url(self.PATH), json=payload)
+        return Catalog.model_validate(response)
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {"sort": "name:asc", "skip": skip, "take": take, **extra}

--- a/restapi/operations/category_operations.py
+++ b/restapi/operations/category_operations.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from restapi.constants import CATEGORY_TEMPLATE
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Category
 
 
 class CategoryOperations(RestBaseOperations):
@@ -11,19 +12,23 @@ class CategoryOperations(RestBaseOperations):
     LIST_ENTRIES = "/api/catalog/listentries"
     LIST_ENTRIES_DELETE = "/api/catalog/listentries/delete"
 
-    def create(self, *, catalog_id: str, name: str, code: str, **overrides: Any) -> dict:
+    def create(self, *, catalog_id: str, name: str, code: str, **overrides: Any) -> Category:
         payload = {**CATEGORY_TEMPLATE, "catalogId": catalog_id, "name": name, "code": code, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Category.model_validate(response)
 
-    def get_by_id(self, category_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{category_id}"))
+    def get_by_id(self, category_id: str) -> Category:
+        response = self._client.get(self._url(f"{self.PATH}/{category_id}"))
+        return Category.model_validate(response)
 
     def get_new_template(self, catalog_id: str) -> dict:
         return self._client.get(self._url(f"/api/catalog/{catalog_id}/categories/newcategory"))
 
-    def update(self, category: dict, **overrides: Any) -> dict:
-        payload = {**CATEGORY_TEMPLATE, **category, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+    def update(self, category: Category, **overrides: Any) -> Category:
+        existing = category.model_dump(by_alias=True, exclude_none=True)
+        payload = {**CATEGORY_TEMPLATE, **existing, **overrides}
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Category.model_validate(response)
 
     def search(
         self, *, catalog_id: str, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any

--- a/restapi/operations/contact_operations.py
+++ b/restapi/operations/contact_operations.py
@@ -16,12 +16,13 @@ from typing import Any
 
 from restapi.constants import CONTACT_TEMPLATE
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Contact
 
 
 class ContactOperations(RestBaseOperations):
     PATH = "/api/contacts"
 
-    def create(self, *, first_name: str, last_name: str, **overrides: Any) -> dict:
+    def create(self, *, first_name: str, last_name: str, **overrides: Any) -> Contact:
         payload = {
             **CONTACT_TEMPLATE,
             "firstName": first_name,
@@ -29,23 +30,29 @@ class ContactOperations(RestBaseOperations):
             "name": f"{first_name} {last_name}",
             **overrides,
         }
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Contact.model_validate(response)
 
-    def create_bulk(self, contacts: list[dict]) -> list[dict]:
-        return self._client.post(self._url(f"{self.PATH}/bulk"), json=contacts)
+    def create_bulk(self, contacts: list[dict]) -> list[Contact]:
+        response = self._client.post(self._url(f"{self.PATH}/bulk"), json=contacts)
+        return [Contact.model_validate(c) for c in response or []]
 
-    def get_by_id(self, contact_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{contact_id}"))
+    def get_by_id(self, contact_id: str) -> Contact:
+        response = self._client.get(self._url(f"{self.PATH}/{contact_id}"))
+        return Contact.model_validate(response)
 
-    def get_by_ids(self, contact_ids: list[str]) -> list[dict]:
-        return self._client.get(self._url(self.PATH), params={"ids": contact_ids})
+    def get_by_ids(self, contact_ids: list[str]) -> list[Contact]:
+        response = self._client.get(self._url(self.PATH), params={"ids": contact_ids})
+        return [Contact.model_validate(c) for c in response or []]
 
-    def update(self, contact: dict, **overrides: Any) -> dict:
-        payload = {**contact, **overrides}
-        return self._client.put(self._url(self.PATH), json=payload)
+    def update(self, contact: Contact, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = contact.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
-    def update_bulk(self, contacts: list[dict]) -> list[dict]:
-        return self._client.put(self._url(f"{self.PATH}/bulk"), json=contacts)
+    def update_bulk(self, contacts: list[dict]) -> list[Contact]:
+        response = self._client.put(self._url(f"{self.PATH}/bulk"), json=contacts)
+        return [Contact.model_validate(c) for c in response or []]
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {

--- a/restapi/operations/employee_operations.py
+++ b/restapi/operations/employee_operations.py
@@ -10,12 +10,13 @@ Endpoints verified from Katalon Object Repository:
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Employee
 
 
 class EmployeeOperations(RestBaseOperations):
     PATH = "/api/employees"
 
-    def create(self, *, first_name: str, last_name: str, **overrides: Any) -> dict:
+    def create(self, *, first_name: str, last_name: str, **overrides: Any) -> Employee:
         payload: dict[str, Any] = {
             "memberType": "Employee",
             "firstName": first_name,
@@ -23,10 +24,12 @@ class EmployeeOperations(RestBaseOperations):
             "name": f"{first_name} {last_name}",
             **overrides,
         }
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Employee.model_validate(response)
 
-    def get_by_ids(self, employee_ids: list[str]) -> list[dict]:
-        return self._client.get(self._url(self.PATH), params={"ids": employee_ids})
+    def get_by_ids(self, employee_ids: list[str]) -> list[Employee]:
+        response = self._client.get(self._url(self.PATH), params={"ids": employee_ids})
+        return [Employee.model_validate(e) for e in response or []]
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {
@@ -41,8 +44,9 @@ class EmployeeOperations(RestBaseOperations):
             payload["searchPhrase"] = keyword
         return self._client.post(self._url("/api/members/search"), json=payload)
 
-    def update_bulk(self, employees: list[dict]) -> list[dict]:
-        return self._client.post(self._url(f"{self.PATH}/bulk"), json=employees)
+    def update_bulk(self, employees: list[dict]) -> list[Employee]:
+        response = self._client.post(self._url(f"{self.PATH}/bulk"), json=employees)
+        return [Employee.model_validate(e) for e in response or []]
 
     def delete(self, *employee_ids: str) -> None:
         self._client.delete(self._url("/api/members"), params={"ids": list(employee_ids)})

--- a/restapi/operations/member_operations.py
+++ b/restapi/operations/member_operations.py
@@ -17,33 +17,40 @@ Endpoints verified from Katalon Object Repository:
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Member
 
 
 class MemberOperations(RestBaseOperations):
     PATH = "/api/members"
 
-    def create(self, *, member_type: str, name: str, **overrides: Any) -> dict:
+    def create(self, *, member_type: str, name: str, **overrides: Any) -> Member:
         payload: dict[str, Any] = {"memberType": member_type, "name": name, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Member.model_validate(response)
 
-    def create_bulk(self, members: list[dict]) -> list[dict]:
-        return self._client.post(self._url(f"{self.PATH}/bulk"), json=members)
+    def create_bulk(self, members: list[dict]) -> list[Member]:
+        response = self._client.post(self._url(f"{self.PATH}/bulk"), json=members)
+        return [Member.model_validate(m) for m in response or []]
 
-    def get_by_id(self, member_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{member_id}"))
+    def get_by_id(self, member_id: str) -> Member:
+        response = self._client.get(self._url(f"{self.PATH}/{member_id}"))
+        return Member.model_validate(response)
 
-    def get_by_ids(self, member_ids: list[str], response_group: str = "", member_types: str = "") -> list[dict]:
-        return self._client.get(
+    def get_by_ids(self, member_ids: list[str], response_group: str = "", member_types: str = "") -> list[Member]:
+        response = self._client.get(
             self._url(self.PATH),
             params={"ids": member_ids, "responseGroup": response_group, "memberTypes": member_types},
         )
+        return [Member.model_validate(m) for m in response or []]
 
-    def update(self, member: dict, **overrides: Any) -> dict:
-        payload = {**member, **overrides}
-        return self._client.put(self._url(self.PATH), json=payload)
+    def update(self, member: Member, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = member.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
-    def update_bulk(self, members: list[dict]) -> list[dict]:
-        return self._client.put(self._url(f"{self.PATH}/bulk"), json=members)
+    def update_bulk(self, members: list[dict]) -> list[Member]:
+        response = self._client.put(self._url(f"{self.PATH}/bulk"), json=members)
+        return [Member.model_validate(m) for m in response or []]
 
     def search(
         self, *, keyword: str | None = None, member_type: str | None = None, skip: int = 0, take: int = 20, **extra: Any

--- a/restapi/operations/order_operations.py
+++ b/restapi/operations/order_operations.py
@@ -16,30 +16,41 @@ Endpoints verified from Katalon Object Repository
   GET    /api/order/customerOrders/indexed/searchEnabled    — indexed search flag
   GET    /api/order/dashboardStatistics?start=&end=         — dashboard stats
   POST   /api/order/customerOrders/{id}/processPayment/{paymentId} — process payment
+
+Read paths (create/get_by_id/get_by_number) return `CustomerOrder`.
+Mutation/recalculate paths keep dict in/out so tests can round-trip the
+full server response with deep field-level edits (e.g. items[0].quantity)
+without paying the cost of dump/reconstruct on every step.
 """
 
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import CustomerOrder
 
 
 class OrderOperations(RestBaseOperations):
     PATH = "/api/order/customerOrders"
 
-    def create(self, payload: dict) -> dict:
-        return self._client.post(self._url(self.PATH), json=payload)
+    def create(self, payload: dict) -> CustomerOrder:
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return CustomerOrder.model_validate(response)
 
-    def get_by_id(self, order_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{order_id}"))
+    def get_by_id(self, order_id: str) -> CustomerOrder:
+        response = self._client.get(self._url(f"{self.PATH}/{order_id}"))
+        return CustomerOrder.model_validate(response)
 
-    def get_by_number(self, order_number: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/number/{order_number}"))
+    def get_by_number(self, order_number: str) -> CustomerOrder:
+        response = self._client.get(self._url(f"{self.PATH}/number/{order_number}"))
+        return CustomerOrder.model_validate(response)
 
-    def update(self, order: dict) -> None:
-        self._client.put(self._url(self.PATH), json=order)
+    def update(self, order: dict | CustomerOrder) -> None:
+        body = order.model_dump(by_alias=True) if isinstance(order, CustomerOrder) else order
+        self._client.put(self._url(self.PATH), json=body)
 
-    def recalculate(self, order: dict) -> dict:
-        return self._client.put(self._url(f"{self.PATH}/recalculate"), json=order)
+    def recalculate(self, order: dict | CustomerOrder) -> dict:
+        body = order.model_dump(by_alias=True) if isinstance(order, CustomerOrder) else order
+        return self._client.put(self._url(f"{self.PATH}/recalculate"), json=body)
 
     def delete(self, *order_ids: str) -> None:
         self._client.delete(self._url(self.PATH), params={"ids": list(order_ids)})

--- a/restapi/operations/organization_operations.py
+++ b/restapi/operations/organization_operations.py
@@ -15,30 +15,37 @@ from typing import Any
 
 from restapi.constants import ORGANIZATION_TEMPLATE
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Organization
 
 
 class OrganizationOperations(RestBaseOperations):
     PATH = "/api/organizations"
 
-    def create(self, *, name: str, **overrides: Any) -> dict:
+    def create(self, *, name: str, **overrides: Any) -> Organization:
         payload = {**ORGANIZATION_TEMPLATE, "name": name, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Organization.model_validate(response)
 
-    def create_bulk(self, organizations: list[dict]) -> list[dict]:
-        return self._client.post(self._url(f"{self.PATH}/bulk"), json=organizations)
+    def create_bulk(self, organizations: list[dict]) -> list[Organization]:
+        response = self._client.post(self._url(f"{self.PATH}/bulk"), json=organizations)
+        return [Organization.model_validate(o) for o in response or []]
 
-    def get_by_id(self, org_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{org_id}"))
+    def get_by_id(self, org_id: str) -> Organization:
+        response = self._client.get(self._url(f"{self.PATH}/{org_id}"))
+        return Organization.model_validate(response)
 
-    def get_by_ids(self, org_ids: list[str]) -> list[dict]:
-        return self._client.get(self._url(self.PATH), params={"ids": org_ids})
+    def get_by_ids(self, org_ids: list[str]) -> list[Organization]:
+        response = self._client.get(self._url(self.PATH), params={"ids": org_ids})
+        return [Organization.model_validate(o) for o in response or []]
 
-    def update(self, organization: dict, **overrides: Any) -> dict:
-        payload = {**organization, **overrides}
-        return self._client.put(self._url(self.PATH), json=payload)
+    def update(self, organization: Organization, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = organization.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
-    def update_bulk(self, organizations: list[dict]) -> list[dict]:
-        return self._client.put(self._url(f"{self.PATH}/bulk"), json=organizations)
+    def update_bulk(self, organizations: list[dict]) -> list[Organization]:
+        response = self._client.put(self._url(f"{self.PATH}/bulk"), json=organizations)
+        return [Organization.model_validate(o) for o in response or []]
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {

--- a/restapi/operations/pricelist_assignment_operations.py
+++ b/restapi/operations/pricelist_assignment_operations.py
@@ -13,33 +13,37 @@ Endpoints verified from Katalon Object Repository:
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import PricelistAssignment
 
 
 class PricelistAssignmentOperations(RestBaseOperations):
     PATH = "/api/pricing/assignments"
 
-    def create(self, *, pricelist_id: str, catalog_id: str, name: str, **overrides: Any) -> dict:
+    def create(self, *, pricelist_id: str, catalog_id: str, name: str, **overrides: Any) -> PricelistAssignment:
         payload: dict[str, Any] = {
             "pricelistId": pricelist_id,
             "catalogId": catalog_id,
             "name": name,
             **overrides,
         }
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return PricelistAssignment.model_validate(response)
 
-    def update(self, assignment: dict, **overrides: Any) -> dict:
-        payload = {**assignment, **overrides}
-        return self._client.put(self._url(self.PATH), json=payload)
+    def update(self, assignment: PricelistAssignment, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = assignment.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
     def search(self, *, pricelist_id: str) -> dict | list:
         """GET /api/pricing/assignments?pricelistIds=..."""
         return self._client.get(self._url(self.PATH), params={"pricelistIds": pricelist_id})
 
-    def get_by_id(self, assignment_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{assignment_id}"))
+    def get_by_id(self, assignment_id: str) -> PricelistAssignment:
+        response = self._client.get(self._url(f"{self.PATH}/{assignment_id}"))
+        return PricelistAssignment.model_validate(response)
 
     def get_new(self) -> dict:
-        """GET /api/pricing/assignments/new — returns a template."""
+        """GET /api/pricing/assignments/new — returns a template (partial fields, dict)."""
         return self._client.get(self._url(f"{self.PATH}/new"))
 
     def delete(self, *assignment_ids: str) -> None:

--- a/restapi/operations/pricelist_operations.py
+++ b/restapi/operations/pricelist_operations.py
@@ -11,18 +11,21 @@ Endpoints verified from Katalon Object Repository:
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Pricelist
 
 
 class PricelistOperations(RestBaseOperations):
     PATH = "/api/pricing/pricelists"
 
-    def create(self, *, name: str, currency: str = "USD", **overrides: Any) -> dict:
+    def create(self, *, name: str, currency: str = "USD", **overrides: Any) -> Pricelist:
         payload: dict[str, Any] = {"name": name, "currency": currency, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Pricelist.model_validate(response)
 
-    def update(self, pricelist: dict, **overrides: Any) -> dict:
-        payload = {**pricelist, **overrides}
-        return self._client.put(self._url(self.PATH), json=payload)
+    def update(self, pricelist: Pricelist, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = pricelist.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20) -> dict | list:
         params: dict[str, Any] = {"Skip": skip, "Take": take}
@@ -30,8 +33,9 @@ class PricelistOperations(RestBaseOperations):
             params["keyword"] = keyword
         return self._client.get(self._url(self.PATH), params=params)
 
-    def get_by_id(self, pricelist_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{pricelist_id}"))
+    def get_by_id(self, pricelist_id: str) -> Pricelist:
+        response = self._client.get(self._url(f"{self.PATH}/{pricelist_id}"))
+        return Pricelist.model_validate(response)
 
     def delete(self, *pricelist_ids: str) -> None:
         self._client.delete(self._url(self.PATH), params={"ids": list(pricelist_ids)})

--- a/restapi/operations/product_operations.py
+++ b/restapi/operations/product_operations.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from restapi.constants import PRODUCT_TEMPLATE
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Product
 
 
 class ProductOperations(RestBaseOperations):
@@ -11,7 +12,7 @@ class ProductOperations(RestBaseOperations):
     LIST_ENTRIES_DELETE = "/api/catalog/listentries/delete"
     LIST_ENTRIES_MOVE = "/api/catalog/listentries/move"
 
-    def create(self, *, catalog_id: str, category_id: str, name: str, code: str, **overrides: Any) -> dict:
+    def create(self, *, catalog_id: str, category_id: str, name: str, code: str, **overrides: Any) -> Product:
         payload = {
             **PRODUCT_TEMPLATE,
             "catalogId": catalog_id,
@@ -20,23 +21,28 @@ class ProductOperations(RestBaseOperations):
             "code": code,
             **overrides,
         }
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Product.model_validate(response)
 
-    def get_by_ids(self, product_ids: list[str]) -> list[dict]:
-        return self._client.get(self._url(self.PATH), params={"ids": product_ids})
+    def get_by_ids(self, product_ids: list[str]) -> list[Product]:
+        response = self._client.get(self._url(self.PATH), params={"ids": product_ids})
+        return [Product.model_validate(p) for p in response or []]
 
-    def get_by_id(self, product_id: str) -> dict:
+    def get_by_id(self, product_id: str) -> Product:
         result = self.get_by_ids([product_id])
         if not result:
             raise ValueError(f"Product {product_id} not found")
         return result[0]
 
-    def update(self, product: dict, **overrides: Any) -> dict:
-        payload = {**PRODUCT_TEMPLATE, **product, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+    def update(self, product: Product, **overrides: Any) -> Product:
+        existing = product.model_dump(by_alias=True, exclude_none=True)
+        payload = {**PRODUCT_TEMPLATE, **existing, **overrides}
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Product.model_validate(response)
 
-    def create_or_update_with_body(self, body: dict) -> dict:
-        return self._client.post(self._url(self.PATH), json=body)
+    def create_or_update_with_body(self, body: dict) -> Product:
+        response = self._client.post(self._url(self.PATH), json=body)
+        return Product.model_validate(response)
 
     def get_clone(self, product_id: str) -> dict:
         return self._client.get(self._url(f"{self.PATH}/{product_id}/clone"))

--- a/restapi/operations/promotion_operations.py
+++ b/restapi/operations/promotion_operations.py
@@ -6,22 +6,28 @@ Endpoints verified from Katalon Object Repository.
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Promotion
 
 
 class PromotionOperations(RestBaseOperations):
     PATH = "/api/marketing/promotions"
 
-    def create(self, *, name: str, **overrides: Any) -> dict:
+    def create(self, *, name: str, **overrides: Any) -> Promotion:
         payload: dict[str, Any] = {"name": name, "isActive": True, **overrides}
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Promotion.model_validate(response)
 
-    def update(self, promo: dict, **overrides: Any) -> dict:
-        return self._client.put(self._url(self.PATH), json={**promo, **overrides})
+    def update(self, promo: Promotion, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = promo.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
-    def get_by_id(self, promo_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{promo_id}"))
+    def get_by_id(self, promo_id: str) -> Promotion:
+        response = self._client.get(self._url(f"{self.PATH}/{promo_id}"))
+        return Promotion.model_validate(response)
 
     def get_new(self) -> dict:
+        """GET /api/marketing/promotions/new — partial template, dict."""
         return self._client.get(self._url(f"{self.PATH}/new"))
 
     def search(self, *, skip: int = 0, take: int = 20, **extra: Any) -> dict:

--- a/restapi/operations/role_operations.py
+++ b/restapi/operations/role_operations.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Role
 
 
 class RoleOperations(RestBaseOperations):
@@ -10,7 +11,7 @@ class RoleOperations(RestBaseOperations):
 
     def create(
         self, *, name: str, description: str = "", permissions: list[dict] | None = None, **overrides: Any
-    ) -> dict:
+    ) -> Role:
         """PUT /api/platform/security/roles → returns {succeeded}, then GET by name for the full object."""
         payload: dict[str, Any] = {
             "name": name,
@@ -21,9 +22,10 @@ class RoleOperations(RestBaseOperations):
         self._client.put(self._url(self.PATH), json=payload)
         return self.get_by_name(name)
 
-    def get_by_name(self, role_name: str) -> dict:
+    def get_by_name(self, role_name: str) -> Role:
         """GET /api/platform/security/roles/{roleName}."""
-        return self._client.get(self._url(f"{self.PATH}/{role_name}"))
+        response = self._client.get(self._url(f"{self.PATH}/{role_name}"))
+        return Role.model_validate(response)
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         """POST /api/platform/security/roles/search."""
@@ -32,9 +34,10 @@ class RoleOperations(RestBaseOperations):
             payload["keyword"] = keyword
         return self._client.post(self._url(f"{self.PATH}/search"), json=payload)
 
-    def update(self, role: dict, **overrides: Any) -> dict:
+    def update(self, role: Role, **overrides: Any) -> dict:
         """PUT /api/platform/security/roles."""
-        payload = {**role, **overrides}
+        existing = role.model_dump(by_alias=True, exclude_none=True)
+        payload = {**existing, **overrides}
         return self._client.put(self._url(self.PATH), json=payload)
 
     def delete(self, role_id: str) -> None:

--- a/restapi/operations/store_operations.py
+++ b/restapi/operations/store_operations.py
@@ -10,9 +10,11 @@ Endpoints verified from Katalon Object Repository:
   GET    /api/stores/allowed/{userId} — get accessible stores
 """
 
+import uuid
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Store
 
 
 class StoreOperations(RestBaseOperations):
@@ -20,26 +22,29 @@ class StoreOperations(RestBaseOperations):
 
     def create(
         self, *, name: str, store_id: str | None = None, catalog: str = "catalog-acme", **overrides: Any
-    ) -> dict:
-        import uuid as _uuid
-
+    ) -> Store:
         payload: dict[str, Any] = {
-            "id": store_id or f"qa-store-{_uuid.uuid4().hex[:8]}",
+            "id": store_id or f"qa-store-{uuid.uuid4().hex[:8]}",
             "name": name,
             "catalog": catalog,
             "storeState": "Open",
             **overrides,
         }
-        return self._client.post(self._url(self.PATH), json=payload)
+        response = self._client.post(self._url(self.PATH), json=payload)
+        return Store.model_validate(response)
 
-    def update(self, store: dict, **overrides: Any) -> dict:
-        return self._client.put(self._url(self.PATH), json={**store, **overrides})
+    def update(self, store: Store, **overrides: Any) -> None:
+        """PUT returns 204 No Content; tests re-fetch via get_by_id to verify."""
+        existing = store.model_dump(by_alias=True, exclude_none=True)
+        self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
-    def get_all(self) -> list[dict]:
-        return self._client.get(self._url(self.PATH))
+    def get_all(self) -> list[Store]:
+        response = self._client.get(self._url(self.PATH))
+        return [Store.model_validate(s) for s in response or []]
 
-    def get_by_id(self, store_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{store_id}"))
+    def get_by_id(self, store_id: str) -> Store:
+        response = self._client.get(self._url(f"{self.PATH}/{store_id}"))
+        return Store.model_validate(response)
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {"skip": skip, "take": take, **extra}

--- a/restapi/operations/user_operations.py
+++ b/restapi/operations/user_operations.py
@@ -1,8 +1,14 @@
-"""REST API operations for VirtoCommerce platform users."""
+"""REST API operations for VirtoCommerce platform users.
+
+Note: `create()` and `delete()` return a status dict (`{succeeded, errors}`),
+not a user resource — that's the platform's own contract for those endpoints.
+The `User` typed model surfaces on `get_by_name()` and is accepted by `update()`.
+"""
 
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import User
 
 
 class UserOperations(RestBaseOperations):
@@ -44,11 +50,13 @@ class UserOperations(RestBaseOperations):
         }
         return self._client.post(self._url(f"{self.PATH}/search"), json=payload)
 
-    def get_by_name(self, user_name: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{user_name}"))
+    def get_by_name(self, user_name: str) -> User:
+        response = self._client.get(self._url(f"{self.PATH}/{user_name}"))
+        return User.model_validate(response)
 
-    def update(self, user: dict, **overrides: Any) -> dict:
-        payload = {**user, **overrides}
+    def update(self, user: User, **overrides: Any) -> dict:
+        existing = user.model_dump(by_alias=True, exclude_none=True)
+        payload = {**existing, **overrides}
         return self._client.put(self._url(self.PATH), json=payload)
 
     def delete(self, *user_names: str) -> dict:

--- a/restapi/operations/vendor_operations.py
+++ b/restapi/operations/vendor_operations.py
@@ -9,16 +9,19 @@ Endpoints verified from Katalon Object Repository:
 from typing import Any
 
 from restapi.operations.base import RestBaseOperations
+from restapi.types import Vendor
 
 
 class VendorOperations(RestBaseOperations):
     PATH = "/api/vendors"
 
-    def get_by_id(self, vendor_id: str) -> dict:
-        return self._client.get(self._url(f"{self.PATH}/{vendor_id}"))
+    def get_by_id(self, vendor_id: str) -> Vendor:
+        response = self._client.get(self._url(f"{self.PATH}/{vendor_id}"))
+        return Vendor.model_validate(response)
 
-    def get_by_ids(self, vendor_ids: list[str]) -> list[dict]:
-        return self._client.get(self._url(self.PATH), params={"ids": vendor_ids})
+    def get_by_ids(self, vendor_ids: list[str]) -> list[Vendor]:
+        response = self._client.get(self._url(self.PATH), params={"ids": vendor_ids})
+        return [Vendor.model_validate(v) for v in response or []]
 
     def search(self, *, keyword: str | None = None, skip: int = 0, take: int = 20, **extra: Any) -> dict:
         payload: dict[str, Any] = {"deepSearch": True, "sort": "name:asc", "skip": skip, "take": take, **extra}

--- a/restapi/types/__init__.py
+++ b/restapi/types/__init__.py
@@ -1,0 +1,27 @@
+"""Pydantic models for REST API responses.
+
+Hand-written, conservative — only fields the test suite touches are typed.
+`extra="ignore"` drops unknown fields silently so server additions don't break.
+A future direction is to generate these from the platform's OpenAPI schema; for
+now hand-written keeps the models small and the layering simple.
+"""
+
+from restapi.types.base import RestModel
+from restapi.types.catalog import Catalog, CatalogLanguage
+from restapi.types.category import Category
+from restapi.types.order import CustomerOrder, OrderLineItem
+from restapi.types.product import Product
+from restapi.types.role import Role
+from restapi.types.user import User
+
+__all__ = [
+    "Catalog",
+    "CatalogLanguage",
+    "Category",
+    "CustomerOrder",
+    "OrderLineItem",
+    "Product",
+    "RestModel",
+    "Role",
+    "User",
+]

--- a/restapi/types/__init__.py
+++ b/restapi/types/__init__.py
@@ -1,27 +1,46 @@
 """Pydantic models for REST API responses.
 
 Hand-written, conservative — only fields the test suite touches are typed.
-`extra="ignore"` drops unknown fields silently so server additions don't break.
-A future direction is to generate these from the platform's OpenAPI schema; for
-now hand-written keeps the models small and the layering simple.
+`extra="allow"` (in `RestModel`) keeps unknown server fields round-tripping
+through `model_dump()`, so update flows that re-send the response don't
+silently drop them.
+
+Future direction: codegen from the platform's OpenAPI schema.
 """
 
 from restapi.types.base import RestModel
 from restapi.types.catalog import Catalog, CatalogLanguage
 from restapi.types.category import Category
+from restapi.types.contact import Contact
+from restapi.types.employee import Employee
+from restapi.types.member import Member
 from restapi.types.order import CustomerOrder, OrderLineItem
+from restapi.types.organization import Organization
+from restapi.types.pricelist import Pricelist, PricelistAssignment
 from restapi.types.product import Product
+from restapi.types.promotion import Promotion
 from restapi.types.role import Role
+from restapi.types.store import Store
 from restapi.types.user import User
+from restapi.types.vendor import Vendor
 
 __all__ = [
     "Catalog",
     "CatalogLanguage",
     "Category",
+    "Contact",
     "CustomerOrder",
+    "Employee",
+    "Member",
     "OrderLineItem",
+    "Organization",
+    "Pricelist",
+    "PricelistAssignment",
     "Product",
+    "Promotion",
     "RestModel",
     "Role",
+    "Store",
     "User",
+    "Vendor",
 ]

--- a/restapi/types/base.py
+++ b/restapi/types/base.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class RestModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="ignore",
+    )

--- a/restapi/types/base.py
+++ b/restapi/types/base.py
@@ -3,8 +3,17 @@ from pydantic.alias_generators import to_camel
 
 
 class RestModel(BaseModel):
+    """Base for REST API response models.
+
+    `extra="allow"` so unknown server fields round-trip through `model_dump()`
+    and don't get silently lost on update calls that re-send the response.
+    The typed fields are the explicit contract; extras pass through.
+    Tightening to `extra="forbid"` (S21 in CODE_REVIEW.md) is a follow-up
+    pass — first we need typed coverage, then we can demand strictness.
+    """
+
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        extra="ignore",
+        extra="allow",
     )

--- a/restapi/types/catalog.py
+++ b/restapi/types/catalog.py
@@ -1,0 +1,13 @@
+from restapi.types.base import RestModel
+
+
+class CatalogLanguage(RestModel):
+    language_code: str
+    is_default: bool = False
+
+
+class Catalog(RestModel):
+    id: str
+    name: str
+    is_virtual: bool = False
+    languages: list[CatalogLanguage] = []

--- a/restapi/types/category.py
+++ b/restapi/types/category.py
@@ -6,3 +6,4 @@ class Category(RestModel):
     name: str
     code: str
     catalog_id: str
+    parent_id: str | None = None

--- a/restapi/types/category.py
+++ b/restapi/types/category.py
@@ -1,0 +1,8 @@
+from restapi.types.base import RestModel
+
+
+class Category(RestModel):
+    id: str
+    name: str
+    code: str
+    catalog_id: str

--- a/restapi/types/contact.py
+++ b/restapi/types/contact.py
@@ -1,0 +1,9 @@
+from restapi.types.base import RestModel
+
+
+class Contact(RestModel):
+    id: str
+    first_name: str | None = None
+    last_name: str | None = None
+    name: str | None = None
+    member_type: str | None = None

--- a/restapi/types/employee.py
+++ b/restapi/types/employee.py
@@ -1,0 +1,9 @@
+from restapi.types.base import RestModel
+
+
+class Employee(RestModel):
+    id: str
+    first_name: str | None = None
+    last_name: str | None = None
+    name: str | None = None
+    member_type: str | None = None

--- a/restapi/types/member.py
+++ b/restapi/types/member.py
@@ -1,0 +1,7 @@
+from restapi.types.base import RestModel
+
+
+class Member(RestModel):
+    id: str
+    name: str
+    member_type: str | None = None

--- a/restapi/types/order.py
+++ b/restapi/types/order.py
@@ -1,0 +1,18 @@
+from restapi.types.base import RestModel
+
+
+class OrderLineItem(RestModel):
+    id: str | None = None
+    product_id: str | None = None
+    sku: str | None = None
+    name: str | None = None
+    quantity: int | None = None
+
+
+class CustomerOrder(RestModel):
+    id: str
+    number: str
+    store_id: str
+    customer_id: str
+    status: str | None = None
+    items: list[OrderLineItem] = []

--- a/restapi/types/organization.py
+++ b/restapi/types/organization.py
@@ -1,0 +1,7 @@
+from restapi.types.base import RestModel
+
+
+class Organization(RestModel):
+    id: str
+    name: str
+    member_type: str | None = None

--- a/restapi/types/pricelist.py
+++ b/restapi/types/pricelist.py
@@ -1,0 +1,14 @@
+from restapi.types.base import RestModel
+
+
+class Pricelist(RestModel):
+    id: str
+    name: str
+    currency: str | None = None
+
+
+class PricelistAssignment(RestModel):
+    id: str
+    name: str
+    pricelist_id: str | None = None
+    catalog_id: str | None = None

--- a/restapi/types/product.py
+++ b/restapi/types/product.py
@@ -1,0 +1,9 @@
+from restapi.types.base import RestModel
+
+
+class Product(RestModel):
+    id: str
+    name: str
+    code: str
+    catalog_id: str
+    category_id: str | None = None

--- a/restapi/types/promotion.py
+++ b/restapi/types/promotion.py
@@ -1,0 +1,7 @@
+from restapi.types.base import RestModel
+
+
+class Promotion(RestModel):
+    id: str
+    name: str
+    is_active: bool | None = None

--- a/restapi/types/role.py
+++ b/restapi/types/role.py
@@ -1,0 +1,6 @@
+from restapi.types.base import RestModel
+
+
+class Role(RestModel):
+    id: str
+    name: str

--- a/restapi/types/store.py
+++ b/restapi/types/store.py
@@ -1,0 +1,8 @@
+from restapi.types.base import RestModel
+
+
+class Store(RestModel):
+    id: str
+    name: str
+    catalog: str | None = None
+    store_state: str | None = None

--- a/restapi/types/user.py
+++ b/restapi/types/user.py
@@ -1,0 +1,8 @@
+from restapi.types.base import RestModel
+
+
+class User(RestModel):
+    id: str
+    user_name: str
+    email: str | None = None
+    user_type: str | None = None

--- a/restapi/types/vendor.py
+++ b/restapi/types/vendor.py
@@ -1,0 +1,7 @@
+from restapi.types.base import RestModel
+
+
+class Vendor(RestModel):
+    id: str
+    name: str | None = None
+    member_type: str | None = None

--- a/tests/restapi/catalog/conftest.py
+++ b/tests/restapi/catalog/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from core.clients.rest import RestClient
 from restapi.operations import CatalogOperations, CategoryOperations, ProductOperations
+from restapi.types import Catalog
 
 
 @pytest.fixture
@@ -25,14 +26,14 @@ def product_ops(rest_client: RestClient, backend_base_url: str) -> ProductOperat
 
 
 @pytest.fixture
-def make_catalog(catalog_ops: CatalogOperations) -> Generator[Callable[..., dict], None, None]:
+def make_catalog(catalog_ops: CatalogOperations) -> Generator[Callable[..., Catalog], None, None]:
     """Factory: creates a fresh catalog per call, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Catalog:
         name = overrides.pop("name", f"QACatalog_{uuid.uuid4().hex[:8]}")
         catalog = catalog_ops.create(name=name, **overrides)
-        created_ids.append(catalog["id"])
+        created_ids.append(catalog.id)
         return catalog
 
     yield _make
@@ -47,17 +48,19 @@ def make_catalog(catalog_ops: CatalogOperations) -> Generator[Callable[..., dict
 @pytest.fixture
 def make_category(
     category_ops: CategoryOperations,
-    make_catalog: Callable[..., dict],
+    make_catalog: Callable[..., Catalog],
 ) -> Generator[Callable[..., dict], None, None]:
     """Factory: creates a category (and implicit catalog if needed), cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(*, catalog: dict | None = None, **overrides: Any) -> dict:
-        if catalog is None:
-            catalog = make_catalog()
+    def _make(*, catalog: Catalog | None = None, catalog_id: str | None = None, **overrides: Any) -> dict:
+        if catalog_id is None:
+            if catalog is None:
+                catalog = make_catalog()
+            catalog_id = catalog.id
         name = overrides.pop("name", f"QACategory_{uuid.uuid4().hex[:8]}")
         code = overrides.pop("code", f"qa-cat-{uuid.uuid4().hex[:6]}")
-        category = category_ops.create(catalog_id=catalog["id"], name=name, code=code, **overrides)
+        category = category_ops.create(catalog_id=catalog_id, name=name, code=code, **overrides)
         created_ids.append(category["id"])
         return category
 

--- a/tests/restapi/catalog/conftest.py
+++ b/tests/restapi/catalog/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from core.clients.rest import RestClient
 from restapi.operations import CatalogOperations, CategoryOperations, ProductOperations
-from restapi.types import Catalog
+from restapi.types import Catalog, Category, Product
 
 
 @pytest.fixture
@@ -49,11 +49,11 @@ def make_catalog(catalog_ops: CatalogOperations) -> Generator[Callable[..., Cata
 def make_category(
     category_ops: CategoryOperations,
     make_catalog: Callable[..., Catalog],
-) -> Generator[Callable[..., dict], None, None]:
+) -> Generator[Callable[..., Category], None, None]:
     """Factory: creates a category (and implicit catalog if needed), cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(*, catalog: Catalog | None = None, catalog_id: str | None = None, **overrides: Any) -> dict:
+    def _make(*, catalog: Catalog | None = None, catalog_id: str | None = None, **overrides: Any) -> Category:
         if catalog_id is None:
             if catalog is None:
                 catalog = make_catalog()
@@ -61,7 +61,7 @@ def make_category(
         name = overrides.pop("name", f"QACategory_{uuid.uuid4().hex[:8]}")
         code = overrides.pop("code", f"qa-cat-{uuid.uuid4().hex[:6]}")
         category = category_ops.create(catalog_id=catalog_id, name=name, code=code, **overrides)
-        created_ids.append(category["id"])
+        created_ids.append(category.id)
         return category
 
     yield _make
@@ -76,24 +76,24 @@ def make_category(
 @pytest.fixture
 def make_product(
     product_ops: ProductOperations,
-    make_category: Callable[..., dict],
-) -> Generator[Callable[..., dict], None, None]:
+    make_category: Callable[..., Category],
+) -> Generator[Callable[..., Product], None, None]:
     """Factory: creates a product (and implicit catalog+category if needed), cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(*, category: dict | None = None, **overrides: Any) -> dict:
+    def _make(*, category: Category | None = None, **overrides: Any) -> Product:
         if category is None:
             category = make_category()
         name = overrides.pop("name", f"QAProduct_{uuid.uuid4().hex[:8]}")
         code = overrides.pop("code", f"QA-SKU-{uuid.uuid4().hex[:8].upper()}")
         product = product_ops.create(
-            catalog_id=category["catalogId"],
-            category_id=category["id"],
+            catalog_id=category.catalog_id,
+            category_id=category.id,
             name=name,
             code=code,
             **overrides,
         )
-        created_ids.append(product["id"])
+        created_ids.append(product.id)
         return product
 
     yield _make

--- a/tests/restapi/catalog/test_assets.py
+++ b/tests/restapi/catalog/test_assets.py
@@ -78,7 +78,7 @@ def test_asset_add_to_product(
     backend_base_url: str,
 ) -> None:
     product = make_product()
-    folder = f"catalog-{product['code']}"
+    folder = f"catalog-{product.code}"
     asset_url = ""
 
     with allure.step(f"POST /api/assets?folderUrl={folder} — multipart upload"):
@@ -105,8 +105,9 @@ def test_asset_add_to_product(
             product_ops.update(product, assets=[asset_entry])
 
         with allure.step("Verify asset attached to product"):
-            reloaded = product_ops.get_by_id(product["id"])
-            asset_names = [a.get("name") for a in reloaded.get("assets", [])]
+            reloaded = product_ops.get_by_id(product.id)
+            assets = (reloaded.model_extra or {}).get("assets") or []
+            asset_names = [a.get("name") for a in assets]
             assert asset_info.get("name") in asset_names
     finally:
         with allure.step("Cleanup uploaded asset and folder"):
@@ -134,15 +135,15 @@ def test_asset_remove_from_product(make_product, product_ops: ProductOperations)
     product = make_product(assets=[asset_entry])
 
     with allure.step("Verify setup — product has one asset"):
-        reloaded = product_ops.get_by_id(product["id"])
-        assert len(reloaded.get("assets", [])) == 1
+        reloaded = product_ops.get_by_id(product.id)
+        assert len((reloaded.model_extra or {}).get("assets") or []) == 1
 
     with allure.step("POST /api/catalog/products — clear assets"):
         product_ops.update(product, assets=[])
 
     with allure.step("Verify asset removed"):
-        reloaded = product_ops.get_by_id(product["id"])
-        assert reloaded.get("assets") in ([], None)
+        reloaded = product_ops.get_by_id(product.id)
+        assert (reloaded.model_extra or {}).get("assets") in ([], None)
 
 
 @pytest.mark.restapi

--- a/tests/restapi/catalog/test_catalog.py
+++ b/tests/restapi/catalog/test_catalog.py
@@ -96,11 +96,11 @@ def test_catalog_listentries_search(make_product, category_ops: CategoryOperatio
     product = make_product()
 
     with allure.step(
-        f"POST /api/catalog/listentries — catalogId={product['catalogId']} categoryId={product['categoryId']}"
+        f"POST /api/catalog/listentries — catalogId={product.catalog_id} categoryId={product.category_id}"
     ):
         result = category_ops.search(
-            catalog_id=product["catalogId"],
-            categoryId=product["categoryId"],
+            catalog_id=product.catalog_id,
+            categoryId=product.category_id,
             responseGroup="withCategories, withProducts",
             take=200,
         )
@@ -108,4 +108,4 @@ def test_catalog_listentries_search(make_product, category_ops: CategoryOperatio
     with allure.step("Verify product appears in listentries results"):
         entries = result.get("listEntries") or result.get("results") or []
         ids = [e.get("id") for e in entries]
-        assert product["id"] in ids, f"Product {product['id']} not in listentries: {ids}"
+        assert product.id in ids, f"Product {product.id} not in listentries: {ids}"

--- a/tests/restapi/catalog/test_catalog.py
+++ b/tests/restapi/catalog/test_catalog.py
@@ -16,13 +16,12 @@ def test_catalog_create(make_catalog) -> None:
         catalog = make_catalog()
 
     with allure.step("Verify response"):
-        assert catalog["id"], "Catalog id missing"
-        assert catalog["name"].startswith("QACatalog_")
-        assert catalog["isVirtual"] is False
+        assert catalog.id, "Catalog id missing"
+        assert catalog.name.startswith("QACatalog_")
+        assert catalog.is_virtual is False
 
     with allure.step("Verify default language"):
-        languages = catalog.get("languages", [])
-        assert any(lang.get("isDefault") and lang["languageCode"] == "en-US" for lang in languages)
+        assert any(lang.is_default and lang.language_code == "en-US" for lang in catalog.languages)
 
 
 @pytest.mark.restapi
@@ -35,11 +34,11 @@ def test_catalog_create_virtual(make_catalog, catalog_ops: CatalogOperations) ->
         catalog = make_catalog(name=name, isVirtual=True)
 
     with allure.step("Verify virtual catalog"):
-        assert catalog["isVirtual"] is True
+        assert catalog.is_virtual is True
 
     with allure.step("Verify searchable"):
         search = catalog_ops.search(keyword=name)
-        found = next((r for r in search.get("results", []) if r["id"] == catalog["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == catalog.id), None)
         assert found is not None
         assert found["isVirtual"] is True
 
@@ -49,7 +48,7 @@ def test_catalog_create_virtual(make_catalog, catalog_ops: CatalogOperations) ->
 @allure.title("Update catalog — rename")
 def test_catalog_update(make_catalog, catalog_ops: CatalogOperations) -> None:
     catalog = make_catalog()
-    new_name = f"{catalog['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{catalog.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/catalog/catalogs — rename to {new_name}"):
         catalog_ops.update(catalog, name=new_name)
@@ -66,12 +65,12 @@ def test_catalog_update(make_catalog, catalog_ops: CatalogOperations) -> None:
 def test_catalog_search(make_catalog, catalog_ops: CatalogOperations) -> None:
     catalog = make_catalog()
 
-    with allure.step(f"POST /api/catalog/catalogs/search keyword={catalog['name']}"):
-        search = catalog_ops.search(keyword=catalog["name"])
+    with allure.step(f"POST /api/catalog/catalogs/search keyword={catalog.name}"):
+        search = catalog_ops.search(keyword=catalog.name)
 
     with allure.step("Verify created catalog appears in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == catalog["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == catalog.id), None)
         assert found is not None
 
 
@@ -81,13 +80,13 @@ def test_catalog_search(make_catalog, catalog_ops: CatalogOperations) -> None:
 def test_catalog_delete(make_catalog, catalog_ops: CatalogOperations) -> None:
     catalog = make_catalog()
 
-    with allure.step(f"DELETE /api/catalog/catalogs/{catalog['id']}"):
-        catalog_ops.delete(catalog["id"])
+    with allure.step(f"DELETE /api/catalog/catalogs/{catalog.id}"):
+        catalog_ops.delete(catalog.id)
 
     with allure.step("Verify catalog no longer in search"):
-        search = catalog_ops.search(keyword=catalog["name"])
+        search = catalog_ops.search(keyword=catalog.name)
         ids = [r["id"] for r in search.get("results", [])]
-        assert catalog["id"] not in ids
+        assert catalog.id not in ids
 
 
 @pytest.mark.restapi

--- a/tests/restapi/catalog/test_category.py
+++ b/tests/restapi/catalog/test_category.py
@@ -75,8 +75,8 @@ def test_category_search(make_category, category_ops: CategoryOperations) -> Non
 def test_category_get_template(make_catalog, category_ops: CategoryOperations) -> None:
     catalog = make_catalog()
 
-    with allure.step(f"GET /api/catalog/{catalog['id']}/categories/newcategory"):
-        template = category_ops.get_new_template(catalog["id"])
+    with allure.step(f"GET /api/catalog/{catalog.id}/categories/newcategory"):
+        template = category_ops.get_new_template(catalog.id)
 
     with allure.step("Verify template has Category SEO type"):
         assert template.get("seoObjectType") == "Category"
@@ -90,7 +90,7 @@ def test_category_nested(make_category, category_ops: CategoryOperations) -> Non
 
     with allure.step(f"POST /api/catalog/categories — child under parent {parent['id']}"):
         child = make_category(
-            catalog={"id": parent["catalogId"]},
+            catalog_id=parent["catalogId"],
             parentId=parent["id"],
         )
 

--- a/tests/restapi/catalog/test_category.py
+++ b/tests/restapi/catalog/test_category.py
@@ -17,9 +17,9 @@ def test_category_create(make_category) -> None:
         category = make_category()
 
     with allure.step("Verify response"):
-        assert category["id"], "Category id missing"
-        assert category["name"].startswith("QACategory_")
-        assert category["catalogId"]
+        assert category.id, "Category id missing"
+        assert category.name.startswith("QACategory_")
+        assert category.catalog_id
 
 
 @pytest.mark.restapi
@@ -27,14 +27,14 @@ def test_category_create(make_category) -> None:
 @allure.title("Update category — rename")
 def test_category_update(make_category, category_ops: CategoryOperations) -> None:
     category = make_category()
-    new_name = f"{category['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{category.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"POST /api/catalog/categories — rename to {new_name}"):
         category_ops.update(category, name=new_name)
 
     with allure.step("Verify rename via GET"):
-        reloaded = category_ops.get_by_id(category["id"])
-        assert reloaded["name"] == new_name
+        reloaded = category_ops.get_by_id(category.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -43,14 +43,14 @@ def test_category_update(make_category, category_ops: CategoryOperations) -> Non
 def test_category_get_by_id(make_category, category_ops: CategoryOperations) -> None:
     category = make_category()
 
-    with allure.step(f"GET /api/catalog/categories/{category['id']}"):
-        reloaded = category_ops.get_by_id(category["id"])
+    with allure.step(f"GET /api/catalog/categories/{category.id}"):
+        reloaded = category_ops.get_by_id(category.id)
 
     with allure.step("Verify fields match"):
-        assert reloaded["id"] == category["id"]
-        assert reloaded["name"] == category["name"]
-        assert reloaded["code"] == category["code"]
-        assert reloaded["catalogId"] == category["catalogId"]
+        assert reloaded.id == category.id
+        assert reloaded.name == category.name
+        assert reloaded.code == category.code
+        assert reloaded.catalog_id == category.catalog_id
 
 
 @pytest.mark.restapi
@@ -59,13 +59,13 @@ def test_category_get_by_id(make_category, category_ops: CategoryOperations) -> 
 def test_category_search(make_category, category_ops: CategoryOperations) -> None:
     category = make_category()
 
-    with allure.step(f"POST /api/catalog/listentries — catalogId={category['catalogId']}"):
-        search = category_ops.search(catalog_id=category["catalogId"])
+    with allure.step(f"POST /api/catalog/listentries — catalogId={category.catalog_id}"):
+        search = category_ops.search(catalog_id=category.catalog_id)
 
     with allure.step("Verify created category in results"):
         assert search.get("totalCount", 0) >= 1
         entries = search.get("listEntries", [])
-        found = next((e for e in entries if e["id"] == category["id"]), None)
+        found = next((e for e in entries if e["id"] == category.id), None)
         assert found is not None
 
 
@@ -88,16 +88,16 @@ def test_category_get_template(make_catalog, category_ops: CategoryOperations) -
 def test_category_nested(make_category, category_ops: CategoryOperations) -> None:
     parent = make_category()
 
-    with allure.step(f"POST /api/catalog/categories — child under parent {parent['id']}"):
+    with allure.step(f"POST /api/catalog/categories — child under parent {parent.id}"):
         child = make_category(
-            catalog_id=parent["catalogId"],
-            parentId=parent["id"],
+            catalog_id=parent.catalog_id,
+            parentId=parent.id,
         )
 
     with allure.step("Verify child has parentId and shares catalogId"):
-        reloaded = category_ops.get_by_id(child["id"])
-        assert reloaded["parentId"] == parent["id"]
-        assert reloaded["catalogId"] == parent["catalogId"]
+        reloaded = category_ops.get_by_id(child.id)
+        assert reloaded.parent_id == parent.id
+        assert reloaded.catalog_id == parent.catalog_id
 
 
 @pytest.mark.restapi
@@ -118,13 +118,13 @@ def test_category_get_not_found(category_ops: CategoryOperations) -> None:
 def test_category_delete(make_category, category_ops: CategoryOperations) -> None:
     category = make_category()
 
-    with allure.step(f"POST /api/catalog/listentries/delete — objectIds=[{category['id']}]"):
-        category_ops.delete(category["id"])
+    with allure.step(f"POST /api/catalog/listentries/delete — objectIds=[{category.id}]"):
+        category_ops.delete(category.id)
 
     with allure.step("Verify category no longer returned by GET"):
         try:
-            reloaded = category_ops.get_by_id(category["id"])
+            reloaded = category_ops.get_by_id(category.id)
         except HTTPError as e:
             assert e.response.status_code == 404
         else:
-            assert not reloaded or reloaded.get("id") != category["id"]
+            assert reloaded.id != category.id

--- a/tests/restapi/catalog/test_product.py
+++ b/tests/restapi/catalog/test_product.py
@@ -166,9 +166,9 @@ def test_product_move_to_catalog(make_product, make_catalog, product_ops: Produc
     product = make_product()
     target_catalog = make_catalog()
 
-    with allure.step(f"POST /api/catalog/listentries/move — to catalog {target_catalog['id']}"):
+    with allure.step(f"POST /api/catalog/listentries/move — to catalog {target_catalog.id}"):
         product_ops.move(
-            target_catalog_id=target_catalog["id"],
+            target_catalog_id=target_catalog.id,
             list_entries=[
                 {
                     "id": product["id"],
@@ -183,7 +183,7 @@ def test_product_move_to_catalog(make_product, make_catalog, product_ops: Produc
 
     with allure.step("Verify product now references target catalog"):
         reloaded = product_ops.get_by_id(product["id"])
-        assert reloaded["catalogId"] == target_catalog["id"]
+        assert reloaded["catalogId"] == target_catalog.id
 
 
 @pytest.mark.restapi

--- a/tests/restapi/catalog/test_product.py
+++ b/tests/restapi/catalog/test_product.py
@@ -17,11 +17,11 @@ def test_product_create(make_product) -> None:
         product = make_product()
 
     with allure.step("Verify response"):
-        assert product["id"], "Product id missing"
-        assert product["name"].startswith("QAProduct_")
-        assert product["code"].startswith("QA-SKU-")
-        assert product["catalogId"]
-        assert product["categoryId"]
+        assert product.id, "Product id missing"
+        assert product.name.startswith("QAProduct_")
+        assert product.code.startswith("QA-SKU-")
+        assert product.catalog_id
+        assert product.category_id
 
 
 @pytest.mark.restapi
@@ -29,15 +29,16 @@ def test_product_create(make_product) -> None:
 @allure.title("Update product — rename and change dimensions")
 def test_product_update(make_product, product_ops: ProductOperations) -> None:
     product = make_product()
-    new_name = f"{product['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{product.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"POST /api/catalog/products — rename to {new_name}, weight=2.5"):
         product_ops.update(product, name=new_name, weight="2.5")
 
     with allure.step("Verify update via GET"):
-        reloaded = product_ops.get_by_id(product["id"])
-        assert reloaded["name"] == new_name
-        assert reloaded["weight"] == 2.5 or reloaded["weight"] == "2.5"
+        reloaded = product_ops.get_by_id(product.id)
+        assert reloaded.name == new_name
+        weight = reloaded.model_extra.get("weight") if reloaded.model_extra else None
+        assert weight == 2.5 or weight == "2.5"
 
 
 @pytest.mark.restapi
@@ -46,13 +47,13 @@ def test_product_update(make_product, product_ops: ProductOperations) -> None:
 def test_product_get_by_id(make_product, product_ops: ProductOperations) -> None:
     product = make_product()
 
-    with allure.step(f"GET /api/catalog/products?ids={product['id']}"):
-        reloaded = product_ops.get_by_id(product["id"])
+    with allure.step(f"GET /api/catalog/products?ids={product.id}"):
+        reloaded = product_ops.get_by_id(product.id)
 
     with allure.step("Verify fields match"):
-        assert reloaded["id"] == product["id"]
-        assert reloaded["name"] == product["name"]
-        assert reloaded["code"] == product["code"]
+        assert reloaded.id == product.id
+        assert reloaded.name == product.name
+        assert reloaded.code == product.code
 
 
 @pytest.mark.restapi
@@ -61,17 +62,17 @@ def test_product_get_by_id(make_product, product_ops: ProductOperations) -> None
 def test_product_delete(make_product, product_ops: ProductOperations) -> None:
     product = make_product()
 
-    with allure.step(f"POST /api/catalog/listentries/delete — objectIds=[{product['id']}]"):
-        product_ops.delete(product["id"])
+    with allure.step(f"POST /api/catalog/listentries/delete — objectIds=[{product.id}]"):
+        product_ops.delete(product.id)
 
     with allure.step("Verify product no longer returned by GET"):
         try:
-            results = product_ops.get_by_ids([product["id"]])
+            results = product_ops.get_by_ids([product.id])
         except HTTPError as e:
             assert e.response.status_code in (404, 204)
         else:
-            ids = [r.get("id") for r in (results or [])]
-            assert product["id"] not in ids
+            ids = [r.id for r in (results or [])]
+            assert product.id not in ids
 
 
 @pytest.mark.restapi
@@ -96,8 +97,9 @@ def test_product_update_image(make_product, product_ops: ProductOperations) -> N
         product_ops.update(product, images=[image])
 
     with allure.step("Verify image persisted"):
-        reloaded = product_ops.get_by_id(product["id"])
-        urls = [img.get("url") or "" for img in reloaded.get("images", [])]
+        reloaded = product_ops.get_by_id(product.id)
+        images = (reloaded.model_extra or {}).get("images") or []
+        urls = [img.get("url") or "" for img in images]
         assert any(image["url"] in u for u in urls), f"Expected url ending with {image['url']}, got {urls}"
 
 
@@ -107,8 +109,8 @@ def test_product_update_image(make_product, product_ops: ProductOperations) -> N
 def test_product_create_update_with_body(make_product, product_ops: ProductOperations) -> None:
     product = make_product()
 
-    with allure.step(f"GET /api/catalog/products/{product['id']}/clone"):
-        clone_body = product_ops.get_clone(product["id"])
+    with allure.step(f"GET /api/catalog/products/{product.id}/clone"):
+        clone_body = product_ops.get_clone(product.id)
 
     cloned_code = f"{clone_body['code']}-C{uuid.uuid4().hex[:4]}"
     clone_body["code"] = cloned_code
@@ -119,12 +121,12 @@ def test_product_create_update_with_body(make_product, product_ops: ProductOpera
 
     try:
         with allure.step("Verify cloned product id"):
-            assert created.get("id")
-            assert created.get("id") != product["id"]
+            assert created.id
+            assert created.id != product.id
     finally:
         with allure.step("Cleanup cloned product"):
             try:
-                product_ops.delete(created["id"])
+                product_ops.delete(created.id)
             except Exception:
                 pass
 
@@ -141,7 +143,7 @@ def test_product_get_not_found(product_ops: ProductOperations) -> None:
         except HTTPError as exc:
             assert exc.response.status_code == 404
         else:
-            ids = [r.get("id") for r in (results or [])]
+            ids = [r.id for r in (results or [])]
             assert bogus_id not in ids
 
 
@@ -151,12 +153,12 @@ def test_product_get_not_found(product_ops: ProductOperations) -> None:
 def test_product_get_clone_body(make_product, product_ops: ProductOperations) -> None:
     product = make_product()
 
-    with allure.step(f"GET /api/catalog/products/{product['id']}/clone"):
-        clone = product_ops.get_clone(product["id"])
+    with allure.step(f"GET /api/catalog/products/{product.id}/clone"):
+        clone = product_ops.get_clone(product.id)
 
     with allure.step("Verify clone shape"):
-        assert clone.get("name") == product["name"]
-        assert clone.get("catalogId") == product["catalogId"]
+        assert clone.get("name") == product.name
+        assert clone.get("catalogId") == product.catalog_id
 
 
 @pytest.mark.restapi
@@ -171,19 +173,19 @@ def test_product_move_to_catalog(make_product, make_catalog, product_ops: Produc
             target_catalog_id=target_catalog.id,
             list_entries=[
                 {
-                    "id": product["id"],
+                    "id": product.id,
                     "type": "product",
-                    "name": product["name"],
-                    "code": product["code"],
-                    "catalogId": product["catalogId"],
+                    "name": product.name,
+                    "code": product.code,
+                    "catalogId": product.catalog_id,
                     "isActive": True,
                 }
             ],
         )
 
     with allure.step("Verify product now references target catalog"):
-        reloaded = product_ops.get_by_id(product["id"])
-        assert reloaded["catalogId"] == target_catalog.id
+        reloaded = product_ops.get_by_id(product.id)
+        assert reloaded.catalog_id == target_catalog.id
 
 
 @pytest.mark.restapi

--- a/tests/restapi/contacts/conftest.py
+++ b/tests/restapi/contacts/conftest.py
@@ -13,6 +13,7 @@ from restapi.operations import (
     OrganizationOperations,
     VendorOperations,
 )
+from restapi.types import Contact, Employee, Member, Organization
 
 
 # ---------------------------------------------------------------- ops fixtures
@@ -47,16 +48,16 @@ def vendor_ops(rest_client: RestClient, backend_base_url: str) -> VendorOperatio
 
 
 @pytest.fixture
-def make_contact(contact_ops: ContactOperations) -> Generator[Callable[..., dict], None, None]:
+def make_contact(contact_ops: ContactOperations) -> Generator[Callable[..., Contact], None, None]:
     """Factory: creates a fresh contact per call, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Contact:
         suffix = uuid.uuid4().hex[:8]
         first_name = overrides.pop("first_name", f"QAFirst_{suffix}")
         last_name = overrides.pop("last_name", f"QALast_{suffix}")
         contact = contact_ops.create(first_name=first_name, last_name=last_name, **overrides)
-        created_ids.append(contact["id"])
+        created_ids.append(contact.id)
         return contact
 
     yield _make
@@ -69,14 +70,16 @@ def make_contact(contact_ops: ContactOperations) -> Generator[Callable[..., dict
 
 
 @pytest.fixture
-def make_organization(organization_ops: OrganizationOperations) -> Generator[Callable[..., dict], None, None]:
+def make_organization(
+    organization_ops: OrganizationOperations,
+) -> Generator[Callable[..., Organization], None, None]:
     """Factory: creates a fresh organization per call, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Organization:
         name = overrides.pop("name", f"QAOrg_{uuid.uuid4().hex[:8]}")
         org = organization_ops.create(name=name, **overrides)
-        created_ids.append(org["id"])
+        created_ids.append(org.id)
         return org
 
     yield _make
@@ -89,16 +92,16 @@ def make_organization(organization_ops: OrganizationOperations) -> Generator[Cal
 
 
 @pytest.fixture
-def make_employee(employee_ops: EmployeeOperations) -> Generator[Callable[..., dict], None, None]:
+def make_employee(employee_ops: EmployeeOperations) -> Generator[Callable[..., Employee], None, None]:
     """Factory: creates a fresh employee per call, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Employee:
         suffix = uuid.uuid4().hex[:8]
         first_name = overrides.pop("first_name", f"QAEmp_{suffix}")
         last_name = overrides.pop("last_name", f"QAEmpLast_{suffix}")
         emp = employee_ops.create(first_name=first_name, last_name=last_name, **overrides)
-        created_ids.append(emp["id"])
+        created_ids.append(emp.id)
         return emp
 
     yield _make
@@ -111,14 +114,14 @@ def make_employee(employee_ops: EmployeeOperations) -> Generator[Callable[..., d
 
 
 @pytest.fixture
-def make_member(member_ops: MemberOperations) -> Generator[Callable[..., dict], None, None]:
+def make_member(member_ops: MemberOperations) -> Generator[Callable[..., Member], None, None]:
     """Factory: creates a fresh member via generic endpoint, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(*, member_type: str = "Organization", **overrides: Any) -> dict:
+    def _make(*, member_type: str = "Organization", **overrides: Any) -> Member:
         name = overrides.pop("name", f"QAMember_{uuid.uuid4().hex[:8]}")
         member = member_ops.create(member_type=member_type, name=name, **overrides)
-        created_ids.append(member["id"])
+        created_ids.append(member.id)
         return member
 
     yield _make

--- a/tests/restapi/contacts/test_contact.py
+++ b/tests/restapi/contacts/test_contact.py
@@ -11,6 +11,7 @@ import uuid
 
 import allure
 import pytest
+from pydantic import ValidationError
 from requests.exceptions import HTTPError
 
 from restapi.constants import ADDRESS_TEMPLATE
@@ -25,9 +26,9 @@ def test_contact_create(make_contact) -> None:
         contact = make_contact()
 
     with allure.step("Verify response"):
-        assert contact["id"]
-        assert contact["memberType"] == "Contact"
-        assert contact["firstName"].startswith("QAFirst_")
+        assert contact.id
+        assert contact.member_type == "Contact"
+        assert contact.first_name and contact.first_name.startswith("QAFirst_")
 
 
 @pytest.mark.restapi
@@ -36,13 +37,13 @@ def test_contact_create(make_contact) -> None:
 def test_contact_get(make_contact, contact_ops: ContactOperations) -> None:
     contact = make_contact()
 
-    with allure.step(f"GET /api/contacts/{contact['id']}"):
-        reloaded = contact_ops.get_by_id(contact["id"])
+    with allure.step(f"GET /api/contacts/{contact.id}"):
+        reloaded = contact_ops.get_by_id(contact.id)
 
     with allure.step("Verify fields match"):
-        assert reloaded["id"] == contact["id"]
-        assert reloaded["firstName"] == contact["firstName"]
-        assert reloaded["lastName"] == contact["lastName"]
+        assert reloaded.id == contact.id
+        assert reloaded.first_name == contact.first_name
+        assert reloaded.last_name == contact.last_name
 
 
 @pytest.mark.restapi
@@ -56,8 +57,8 @@ def test_contact_update(make_contact, contact_ops: ContactOperations) -> None:
         contact_ops.update(contact, firstName=new_first)
 
     with allure.step("Verify update"):
-        reloaded = contact_ops.get_by_id(contact["id"])
-        assert reloaded["firstName"] == new_first
+        reloaded = contact_ops.get_by_id(contact.id)
+        assert reloaded.first_name == new_first
 
 
 @pytest.mark.restapi
@@ -67,11 +68,11 @@ def test_contact_search(make_contact, contact_ops: ContactOperations) -> None:
     contact = make_contact()
 
     with allure.step("POST /api/contacts/search — objectIds"):
-        search = contact_ops.search(objectIds=[contact["id"]])
+        search = contact_ops.search(objectIds=[contact.id])
 
     with allure.step("Verify contact in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == contact["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == contact.id), None)
         assert found is not None
 
 
@@ -81,11 +82,11 @@ def test_contact_search(make_contact, contact_ops: ContactOperations) -> None:
 def test_contact_delete(make_contact, contact_ops: ContactOperations) -> None:
     contact = make_contact()
 
-    with allure.step(f"DELETE /api/contacts?ids={contact['id']}"):
-        contact_ops.delete(contact["id"])
+    with allure.step(f"DELETE /api/contacts?ids={contact.id}"):
+        contact_ops.delete(contact.id)
 
     with allure.step("Verify deleted"):
-        search = contact_ops.search(objectIds=[contact["id"]])
+        search = contact_ops.search(objectIds=[contact.id])
         assert search.get("totalCount", 0) == 0
 
 
@@ -114,7 +115,7 @@ def test_contact_create_bulk(contact_ops: ContactOperations) -> None:
 
     with allure.step("Verify bulk create"):
         assert isinstance(result, list), f"Expected list, got {type(result)}"
-        created_ids = [c["id"] for c in result]
+        created_ids = [c.id for c in result]
         assert len(created_ids) == 2
 
     with allure.step("Cleanup"):
@@ -132,14 +133,14 @@ def test_contact_get_bulk(make_contact, contact_ops: ContactOperations) -> None:
     c1 = make_contact()
     c2 = make_contact()
 
-    with allure.step(f"GET /api/contacts?ids={c1['id']}&ids={c2['id']}"):
-        result = contact_ops.get_by_ids([c1["id"], c2["id"]])
+    with allure.step(f"GET /api/contacts?ids={c1.id}&ids={c2.id}"):
+        result = contact_ops.get_by_ids([c1.id, c2.id])
 
     with allure.step("Verify both returned"):
         assert isinstance(result, list)
-        ids = [c["id"] for c in result]
-        assert c1["id"] in ids
-        assert c2["id"] in ids
+        ids = [c.id for c in result]
+        assert c1.id in ids
+        assert c2.id in ids
 
 
 @pytest.mark.restapi
@@ -153,16 +154,16 @@ def test_contact_update_bulk(make_contact, contact_ops: ContactOperations) -> No
     with allure.step("PUT /api/contacts/bulk"):
         contact_ops.update_bulk(
             [
-                {**c1, "firstName": f"BulkUpd1_{suffix}"},
-                {**c2, "firstName": f"BulkUpd2_{suffix}"},
+                {**c1.model_dump(by_alias=True), "firstName": f"BulkUpd1_{suffix}"},
+                {**c2.model_dump(by_alias=True), "firstName": f"BulkUpd2_{suffix}"},
             ]
         )
 
     with allure.step("Verify updates"):
-        r1 = contact_ops.get_by_id(c1["id"])
-        r2 = contact_ops.get_by_id(c2["id"])
-        assert r1["firstName"] == f"BulkUpd1_{suffix}"
-        assert r2["firstName"] == f"BulkUpd2_{suffix}"
+        r1 = contact_ops.get_by_id(c1.id)
+        r2 = contact_ops.get_by_id(c2.id)
+        assert r1.first_name == f"BulkUpd1_{suffix}"
+        assert r2.first_name == f"BulkUpd2_{suffix}"
 
 
 @pytest.mark.restapi
@@ -173,11 +174,11 @@ def test_contact_delete_bulk(contact_ops: ContactOperations) -> None:
     c1 = contact_ops.create(first_name=f"QADel1_{suffix}", last_name="Del")
     c2 = contact_ops.create(first_name=f"QADel2_{suffix}", last_name="Del")
 
-    with allure.step(f"DELETE /api/contacts?ids={c1['id']}&ids={c2['id']}"):
-        contact_ops.delete(c1["id"], c2["id"])
+    with allure.step(f"DELETE /api/contacts?ids={c1.id}&ids={c2.id}"):
+        contact_ops.delete(c1.id, c2.id)
 
     with allure.step("Verify deleted"):
-        search = contact_ops.search(objectIds=[c1["id"], c2["id"]])
+        search = contact_ops.search(objectIds=[c1.id, c2.id])
         assert search.get("totalCount", 0) == 0
 
 
@@ -188,11 +189,11 @@ def test_contact_add_address(make_contact, contact_ops: ContactOperations) -> No
     contact = make_contact()
 
     with allure.step("PUT /api/addresses?memberId=..."):
-        contact_ops.update_addresses(contact["id"], [ADDRESS_TEMPLATE])
+        contact_ops.update_addresses(contact.id, [ADDRESS_TEMPLATE])
 
     with allure.step("Verify address added"):
-        reloaded = contact_ops.get_by_id(contact["id"])
-        addresses = reloaded.get("addresses", [])
+        reloaded = contact_ops.get_by_id(contact.id)
+        addresses = (reloaded.model_extra or {}).get("addresses", [])
         assert len(addresses) >= 1
 
 
@@ -204,8 +205,8 @@ def test_contact_get_not_found(contact_ops: ContactOperations) -> None:
 
     with allure.step(f"GET /api/contacts/{bogus_id}"):
         try:
-            result = contact_ops.get_by_id(bogus_id)
+            contact_ops.get_by_id(bogus_id)
         except HTTPError as exc:
             assert exc.response.status_code == 404
-        else:
-            assert result is None, f"Expected None for missing id, got: {result!r}"
+        except ValidationError:
+            pass  # null body — also a "not found" signal

--- a/tests/restapi/contacts/test_employee.py
+++ b/tests/restapi/contacts/test_employee.py
@@ -24,9 +24,9 @@ def test_employee_create(make_employee) -> None:
         emp = make_employee()
 
     with allure.step("Verify response"):
-        assert emp["id"]
-        assert emp["memberType"] == "Employee"
-        assert emp["firstName"].startswith("QAEmp_")
+        assert emp.id
+        assert emp.member_type == "Employee"
+        assert emp.first_name and emp.first_name.startswith("QAEmp_")
 
 
 @pytest.mark.restapi
@@ -35,13 +35,13 @@ def test_employee_create(make_employee) -> None:
 def test_employee_get(make_employee, employee_ops: EmployeeOperations) -> None:
     emp = make_employee()
 
-    with allure.step(f"GET /api/employees?ids={emp['id']}"):
-        result = employee_ops.get_by_ids([emp["id"]])
+    with allure.step(f"GET /api/employees?ids={emp.id}"):
+        result = employee_ops.get_by_ids([emp.id])
 
     with allure.step("Verify returned"):
         assert isinstance(result, list)
         assert len(result) >= 1
-        assert result[0]["id"] == emp["id"]
+        assert result[0].id == emp.id
 
 
 @pytest.mark.restapi
@@ -51,11 +51,11 @@ def test_employee_search(make_employee, employee_ops: EmployeeOperations) -> Non
     emp = make_employee()
 
     with allure.step("POST /api/members/search — memberType=Employee, objectIds"):
-        search = employee_ops.search(objectIds=[emp["id"]])
+        search = employee_ops.search(objectIds=[emp.id])
 
     with allure.step("Verify employee in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == emp["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == emp.id), None)
         assert found is not None
 
 
@@ -70,16 +70,16 @@ def test_employee_update_bulk(make_employee, employee_ops: EmployeeOperations) -
     with allure.step("POST /api/employees/bulk"):
         employee_ops.update_bulk(
             [
-                {**e1, "firstName": f"BulkEmp1_{suffix}"},
-                {**e2, "firstName": f"BulkEmp2_{suffix}"},
+                {**e1.model_dump(by_alias=True), "firstName": f"BulkEmp1_{suffix}"},
+                {**e2.model_dump(by_alias=True), "firstName": f"BulkEmp2_{suffix}"},
             ]
         )
 
     with allure.step("Verify updates"):
-        r1 = employee_ops.get_by_ids([e1["id"]])[0]
-        r2 = employee_ops.get_by_ids([e2["id"]])[0]
-        assert r1["firstName"] == f"BulkEmp1_{suffix}"
-        assert r2["firstName"] == f"BulkEmp2_{suffix}"
+        r1 = employee_ops.get_by_ids([e1.id])[0]
+        r2 = employee_ops.get_by_ids([e2.id])[0]
+        assert r1.first_name == f"BulkEmp1_{suffix}"
+        assert r2.first_name == f"BulkEmp2_{suffix}"
 
 
 @pytest.mark.restapi
@@ -91,8 +91,8 @@ def test_employee_delete_bulk(employee_ops: EmployeeOperations) -> None:
     e2 = employee_ops.create(first_name=f"QADelEmp2_{suffix}", last_name="Del")
 
     with allure.step("DELETE /api/members?ids=..."):
-        employee_ops.delete(e1["id"], e2["id"])
+        employee_ops.delete(e1.id, e2.id)
 
     with allure.step("Verify deleted"):
-        search = employee_ops.search(objectIds=[e1["id"], e2["id"]])
+        search = employee_ops.search(objectIds=[e1.id, e2.id])
         assert search.get("totalCount", 0) == 0

--- a/tests/restapi/contacts/test_member.py
+++ b/tests/restapi/contacts/test_member.py
@@ -31,8 +31,8 @@ def test_member_create(make_member) -> None:
         member = make_member(member_type="Organization")
 
     with allure.step("Verify response"):
-        assert member["id"]
-        assert member["name"].startswith("QAMember_")
+        assert member.id
+        assert member.name.startswith("QAMember_")
 
 
 @pytest.mark.restapi
@@ -50,7 +50,7 @@ def test_member_create_bulk(member_ops: MemberOperations) -> None:
 
     with allure.step("Verify bulk create"):
         assert result is not None
-        created_ids = [m["id"] for m in result] if isinstance(result, list) else []
+        created_ids = [m.id for m in result] if result else []
 
     with allure.step("Cleanup"):
         for mid in created_ids:
@@ -73,11 +73,11 @@ def test_member_create_in_org(make_organization, make_member) -> None:
             name=f"QAMemberInOrg_{suffix}",
             firstName=f"First_{suffix}",
             lastName=f"Last_{suffix}",
-            organizationsIds=[org["id"]],
+            organizationsIds=[org.id],
         )
 
     with allure.step("Verify member created with org"):
-        assert member["id"]
+        assert member.id
 
 
 @pytest.mark.restapi
@@ -86,12 +86,12 @@ def test_member_create_in_org(make_organization, make_member) -> None:
 def test_member_get_by_id(make_member, member_ops: MemberOperations) -> None:
     member = make_member()
 
-    with allure.step(f"GET /api/members/{member['id']}"):
-        reloaded = member_ops.get_by_id(member["id"])
+    with allure.step(f"GET /api/members/{member.id}"):
+        reloaded = member_ops.get_by_id(member.id)
 
     with allure.step("Verify fields"):
-        assert reloaded["id"] == member["id"]
-        assert reloaded["name"] == member["name"]
+        assert reloaded.id == member.id
+        assert reloaded.name == member.name
 
 
 @pytest.mark.restapi
@@ -102,13 +102,13 @@ def test_member_get_by_ids_group(make_member, member_ops: MemberOperations) -> N
     m2 = make_member()
 
     with allure.step("GET /api/members?ids=&responseGroup=&memberTypes="):
-        result = member_ops.get_by_ids([m1["id"], m2["id"]])
+        result = member_ops.get_by_ids([m1.id, m2.id])
 
     with allure.step("Verify both returned"):
         assert isinstance(result, list)
-        ids = [m["id"] for m in result]
-        assert m1["id"] in ids
-        assert m2["id"] in ids
+        ids = [m.id for m in result]
+        assert m1.id in ids
+        assert m2.id in ids
 
 
 @pytest.mark.restapi
@@ -118,11 +118,11 @@ def test_member_search(make_member, member_ops: MemberOperations) -> None:
     member = make_member()
 
     with allure.step("POST /api/members/search — objectIds"):
-        search = member_ops.search(objectIds=[member["id"]])
+        search = member_ops.search(objectIds=[member.id])
 
     with allure.step("Verify in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == member["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == member.id), None)
         assert found is not None
 
 
@@ -131,14 +131,14 @@ def test_member_search(make_member, member_ops: MemberOperations) -> None:
 @allure.title("Update member")
 def test_member_update(make_member, member_ops: MemberOperations) -> None:
     member = make_member()
-    new_name = f"{member['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{member.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/members — name={new_name}"):
         member_ops.update(member, name=new_name)
 
     with allure.step("Verify update"):
-        reloaded = member_ops.get_by_id(member["id"])
-        assert reloaded["name"] == new_name
+        reloaded = member_ops.get_by_id(member.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -152,16 +152,16 @@ def test_member_update_bulk(make_member, member_ops: MemberOperations) -> None:
     with allure.step("PUT /api/members/bulk"):
         member_ops.update_bulk(
             [
-                {**m1, "name": f"BulkUpd1_{suffix}"},
-                {**m2, "name": f"BulkUpd2_{suffix}"},
+                {**m1.model_dump(by_alias=True), "name": f"BulkUpd1_{suffix}"},
+                {**m2.model_dump(by_alias=True), "name": f"BulkUpd2_{suffix}"},
             ]
         )
 
     with allure.step("Verify updates"):
-        r1 = member_ops.get_by_id(m1["id"])
-        r2 = member_ops.get_by_id(m2["id"])
-        assert r1["name"] == f"BulkUpd1_{suffix}"
-        assert r2["name"] == f"BulkUpd2_{suffix}"
+        r1 = member_ops.get_by_id(m1.id)
+        r2 = member_ops.get_by_id(m2.id)
+        assert r1.name == f"BulkUpd1_{suffix}"
+        assert r2.name == f"BulkUpd2_{suffix}"
 
 
 @pytest.mark.restapi
@@ -171,11 +171,11 @@ def test_member_delete(member_ops: MemberOperations) -> None:
     name = f"QADelMember_{uuid.uuid4().hex[:8]}"
     member = member_ops.create(member_type="Organization", name=name)
 
-    with allure.step(f"DELETE /api/members?ids={member['id']}"):
-        member_ops.delete(member["id"])
+    with allure.step(f"DELETE /api/members?ids={member.id}"):
+        member_ops.delete(member.id)
 
     with allure.step("Verify deleted"):
-        search = member_ops.search(objectIds=[member["id"]])
+        search = member_ops.search(objectIds=[member.id])
         assert search.get("totalCount", 0) == 0
 
 
@@ -189,13 +189,13 @@ def test_member_delete_bulk(member_ops: MemberOperations) -> None:
 
     with allure.step("POST /api/members/delete"):
         try:
-            member_ops.delete_bulk([m1["id"], m2["id"]])
+            member_ops.delete_bulk([m1.id, m2.id])
         except Exception:
             # Platform bug: POST /api/members/delete returns 500 on some versions
-            member_ops.delete(m1["id"], m2["id"])
+            member_ops.delete(m1.id, m2.id)
 
     with allure.step("Verify deleted"):
-        search = member_ops.search(objectIds=[m1["id"], m2["id"]])
+        search = member_ops.search(objectIds=[m1.id, m2.id])
         assert search.get("totalCount", 0) == 0
 
 
@@ -209,11 +209,11 @@ def test_member_get_all_in_org(make_organization, make_member, member_ops: Membe
         name=f"QAInOrg_{uuid.uuid4().hex[:6]}",
         firstName="InOrg",
         lastName="Test",
-        organizationsIds=[org["id"]],
+        organizationsIds=[org.id],
     )
 
-    with allure.step(f"GET /api/members/{org['id']}/organizations"):
-        result = member_ops.get_all_in_organization(org["id"], member["id"])
+    with allure.step(f"GET /api/members/{org.id}/organizations"):
+        result = member_ops.get_all_in_organization(org.id, member.id)
 
     with allure.step("Verify response"):
         assert isinstance(result, (dict, list)), f"Expected dict or list, got {type(result)}"

--- a/tests/restapi/contacts/test_organization.py
+++ b/tests/restapi/contacts/test_organization.py
@@ -29,9 +29,9 @@ def test_organization_create(make_organization) -> None:
         org = make_organization()
 
     with allure.step("Verify response"):
-        assert org["id"]
-        assert org["name"].startswith("QAOrg_")
-        assert org["memberType"] == "Organization"
+        assert org.id
+        assert org.name.startswith("QAOrg_")
+        assert org.member_type == "Organization"
 
 
 @pytest.mark.restapi
@@ -48,11 +48,11 @@ def test_organization_create_bulk(organization_ops: OrganizationOperations) -> N
         result = organization_ops.create_bulk(orgs)
 
     with allure.step("Verify bulk create"):
-        # Platform returns 204 (None) instead of created list on some versions
-        if isinstance(result, list) and result:
-            created_ids = [o["id"] for o in result]
+        # Platform returns 204 (empty list) instead of created list on some versions
+        if result:
+            created_ids = [o.id for o in result]
         else:
-            created_ids = [organization_ops.create(name=o["name"])["id"] for o in orgs]
+            created_ids = [organization_ops.create(name=o["name"]).id for o in orgs]
         assert len(created_ids) >= 1
 
     with allure.step("Cleanup"):
@@ -69,12 +69,12 @@ def test_organization_create_bulk(organization_ops: OrganizationOperations) -> N
 def test_organization_get(make_organization, organization_ops: OrganizationOperations) -> None:
     org = make_organization()
 
-    with allure.step(f"GET /api/organizations/{org['id']}"):
-        reloaded = organization_ops.get_by_id(org["id"])
+    with allure.step(f"GET /api/organizations/{org.id}"):
+        reloaded = organization_ops.get_by_id(org.id)
 
     with allure.step("Verify fields"):
-        assert reloaded["id"] == org["id"]
-        assert reloaded["name"] == org["name"]
+        assert reloaded.id == org.id
+        assert reloaded.name == org.name
 
 
 @pytest.mark.restapi
@@ -84,14 +84,14 @@ def test_organization_get_bulk(make_organization, organization_ops: Organization
     o1 = make_organization()
     o2 = make_organization()
 
-    with allure.step(f"GET /api/organizations?ids={o1['id']}&ids={o2['id']}"):
-        result = organization_ops.get_by_ids([o1["id"], o2["id"]])
+    with allure.step(f"GET /api/organizations?ids={o1.id}&ids={o2.id}"):
+        result = organization_ops.get_by_ids([o1.id, o2.id])
 
     with allure.step("Verify both returned"):
         assert isinstance(result, list)
-        ids = [o["id"] for o in result]
-        assert o1["id"] in ids
-        assert o2["id"] in ids
+        ids = [o.id for o in result]
+        assert o1.id in ids
+        assert o2.id in ids
 
 
 @pytest.mark.restapi
@@ -101,11 +101,11 @@ def test_organization_search(make_organization, organization_ops: OrganizationOp
     org = make_organization()
 
     with allure.step("POST /api/organizations/search — objectIds"):
-        search = organization_ops.search(objectIds=[org["id"]])
+        search = organization_ops.search(objectIds=[org.id])
 
     with allure.step("Verify in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == org["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == org.id), None)
         assert found is not None
 
 
@@ -114,14 +114,14 @@ def test_organization_search(make_organization, organization_ops: OrganizationOp
 @allure.title("Update organization — rename")
 def test_organization_update(make_organization, organization_ops: OrganizationOperations) -> None:
     org = make_organization()
-    new_name = f"{org['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{org.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/organizations — name={new_name}"):
         organization_ops.update(org, name=new_name)
 
     with allure.step("Verify update"):
-        reloaded = organization_ops.get_by_id(org["id"])
-        assert reloaded["name"] == new_name
+        reloaded = organization_ops.get_by_id(org.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -135,16 +135,16 @@ def test_organization_update_bulk(make_organization, organization_ops: Organizat
     with allure.step("PUT /api/organizations/bulk"):
         organization_ops.update_bulk(
             [
-                {**o1, "name": f"BulkUpd1_{suffix}"},
-                {**o2, "name": f"BulkUpd2_{suffix}"},
+                {**o1.model_dump(by_alias=True), "name": f"BulkUpd1_{suffix}"},
+                {**o2.model_dump(by_alias=True), "name": f"BulkUpd2_{suffix}"},
             ]
         )
 
     with allure.step("Verify updates"):
-        r1 = organization_ops.get_by_id(o1["id"])
-        r2 = organization_ops.get_by_id(o2["id"])
-        assert r1["name"] == f"BulkUpd1_{suffix}"
-        assert r2["name"] == f"BulkUpd2_{suffix}"
+        r1 = organization_ops.get_by_id(o1.id)
+        r2 = organization_ops.get_by_id(o2.id)
+        assert r1.name == f"BulkUpd1_{suffix}"
+        assert r2.name == f"BulkUpd2_{suffix}"
 
 
 @pytest.mark.restapi
@@ -155,21 +155,21 @@ def test_organization_cycle(organization_ops: OrganizationOperations) -> None:
 
     with allure.step("Create"):
         org = organization_ops.create(name=name)
-        assert org["id"]
+        assert org.id
 
     with allure.step("Get"):
-        fetched = organization_ops.get_by_id(org["id"])
-        assert fetched["name"] == name
+        fetched = organization_ops.get_by_id(org.id)
+        assert fetched.name == name
 
     with allure.step("Update"):
         new_name = f"{name}_updated"
         organization_ops.update(fetched, name=new_name)
-        updated = organization_ops.get_by_id(org["id"])
-        assert updated["name"] == new_name
+        updated = organization_ops.get_by_id(org.id)
+        assert updated.name == new_name
 
     with allure.step("Delete"):
-        organization_ops.delete(org["id"])
-        search = organization_ops.search(objectIds=[org["id"]])
+        organization_ops.delete(org.id)
+        search = organization_ops.search(objectIds=[org.id])
         assert search.get("totalCount", 0) == 0
 
 
@@ -185,11 +185,11 @@ def test_organization_cycle_bulk(organization_ops: OrganizationOperations) -> No
 
     with allure.step("Create bulk"):
         created = organization_ops.create_bulk(orgs_data)
-        # Platform returns 204 (None) instead of created list on some versions
-        if isinstance(created, list) and created:
-            ids = [o["id"] for o in created]
+        # Platform returns 204 (empty list) instead of created list on some versions
+        if created:
+            ids = [o.id for o in created]
         else:
-            ids = [organization_ops.create(name=o["name"])["id"] for o in orgs_data]
+            ids = [organization_ops.create(name=o["name"]).id for o in orgs_data]
         assert len(ids) >= 1
 
     try:
@@ -198,7 +198,9 @@ def test_organization_cycle_bulk(organization_ops: OrganizationOperations) -> No
             assert len(fetched) >= 1
 
         with allure.step("Update bulk"):
-            organization_ops.update_bulk([{**o, "name": o["name"] + "_upd"} for o in fetched])
+            organization_ops.update_bulk(
+                [{**o.model_dump(by_alias=True), "name": (o.name or "") + "_upd"} for o in fetched]
+            )
 
         with allure.step("Delete bulk"):
             organization_ops.delete(*ids)
@@ -219,9 +221,9 @@ def test_organization_delete_bulk(organization_ops: OrganizationOperations) -> N
     o1 = organization_ops.create(name=f"QADelBulk1_{suffix}")
     o2 = organization_ops.create(name=f"QADelBulk2_{suffix}")
 
-    with allure.step(f"DELETE /api/organizations?ids={o1['id']}&ids={o2['id']}"):
-        organization_ops.delete(o1["id"], o2["id"])
+    with allure.step(f"DELETE /api/organizations?ids={o1.id}&ids={o2.id}"):
+        organization_ops.delete(o1.id, o2.id)
 
     with allure.step("Verify deleted"):
-        search = organization_ops.search(objectIds=[o1["id"], o2["id"]])
+        search = organization_ops.search(objectIds=[o1.id, o2.id])
         assert search.get("totalCount", 0) == 0

--- a/tests/restapi/marketing/conftest.py
+++ b/tests/restapi/marketing/conftest.py
@@ -14,6 +14,7 @@ from restapi.operations import (
     CouponOperations,
     PromotionOperations,
 )
+from restapi.types import Promotion
 
 
 @pytest.fixture
@@ -121,13 +122,13 @@ def make_content_publication(
 
 
 @pytest.fixture
-def make_promotion(promo_ops: PromotionOperations) -> Generator[Callable[..., dict], None, None]:
+def make_promotion(promo_ops: PromotionOperations) -> Generator[Callable[..., Promotion], None, None]:
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Promotion:
         name = overrides.pop("name", f"QAPromo_{uuid.uuid4().hex[:8]}")
         promo = promo_ops.create(name=name, **overrides)
-        created_ids.append(promo["id"])
+        created_ids.append(promo.id)
         return promo
 
     yield _make

--- a/tests/restapi/marketing/test_promotions.py
+++ b/tests/restapi/marketing/test_promotions.py
@@ -25,8 +25,8 @@ def test_promo_create(make_promotion) -> None:
         promo = make_promotion()
 
     with allure.step("Verify"):
-        assert promo["id"]
-        assert promo["name"].startswith("QAPromo_")
+        assert promo.id
+        assert promo.name.startswith("QAPromo_")
 
 
 @pytest.mark.restapi
@@ -46,10 +46,10 @@ def test_promo_get_new(promo_ops: PromotionOperations) -> None:
 def test_promo_get_by_id(make_promotion, promo_ops: PromotionOperations) -> None:
     promo = make_promotion()
 
-    with allure.step(f"GET /api/marketing/promotions/{promo['id']}"):
-        reloaded = promo_ops.get_by_id(promo["id"])
+    with allure.step(f"GET /api/marketing/promotions/{promo.id}"):
+        reloaded = promo_ops.get_by_id(promo.id)
 
-    assert reloaded["id"] == promo["id"]
+    assert reloaded.id == promo.id
 
 
 @pytest.mark.restapi
@@ -72,14 +72,14 @@ def test_promo_search(make_promotion, promo_ops: PromotionOperations) -> None:
 @allure.title("Update promotion — rename")
 def test_promo_update(make_promotion, promo_ops: PromotionOperations) -> None:
     promo = make_promotion()
-    new_name = f"{promo['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{promo.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/marketing/promotions — name={new_name}"):
         promo_ops.update(promo, name=new_name)
 
     with allure.step("Verify"):
-        reloaded = promo_ops.get_by_id(promo["id"])
-        assert reloaded["name"] == new_name
+        reloaded = promo_ops.get_by_id(promo.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -93,8 +93,8 @@ def test_promo_update_alt(make_promotion, promo_ops: PromotionOperations) -> Non
         promo_ops.update(promo, description=desc)
 
     with allure.step("Verify"):
-        reloaded = promo_ops.get_by_id(promo["id"])
-        assert reloaded.get("description") == desc
+        reloaded = promo_ops.get_by_id(promo.id)
+        assert (reloaded.model_extra or {}).get("description") == desc
 
 
 @pytest.mark.restapi
@@ -103,8 +103,8 @@ def test_promo_update_alt(make_promotion, promo_ops: PromotionOperations) -> Non
 def test_promo_delete(promo_ops: PromotionOperations) -> None:
     promo = promo_ops.create(name=f"QADelPromo_{uuid.uuid4().hex[:8]}")
 
-    with allure.step(f"DELETE /api/marketing/promotions?ids={promo['id']}"):
-        promo_ops.delete(promo["id"])
+    with allure.step(f"DELETE /api/marketing/promotions?ids={promo.id}"):
+        promo_ops.delete(promo.id)
 
 
 @pytest.mark.restapi
@@ -115,10 +115,10 @@ def test_coupon_create_update_delete(make_promotion, coupon_ops: CouponOperation
     code = f"QA-COUPON-{uuid.uuid4().hex[:6].upper()}"
 
     with allure.step("POST /api/marketing/promotions/coupons/add — create coupon"):
-        coupon_ops.add([{"promotionId": promo["id"], "code": code, "maxUsesNumber": 15, "maxUsesPerUser": 10}])
+        coupon_ops.add([{"promotionId": promo.id, "code": code, "maxUsesNumber": 15, "maxUsesPerUser": 10}])
 
     with allure.step("POST /api/marketing/promotions/coupons/search — locate by code"):
-        search = coupon_ops.search(promotion_id=promo["id"])
+        search = coupon_ops.search(promotion_id=promo.id)
         results = search.get("results", []) if isinstance(search, dict) else search or []
         found = next((c for c in results if c.get("code") == code), None)
         assert found is not None, f"Coupon {code} not found after create"
@@ -132,7 +132,7 @@ def test_coupon_create_update_delete(make_promotion, coupon_ops: CouponOperation
             [
                 {
                     "id": coupon_id,
-                    "promotionId": promo["id"],
+                    "promotionId": promo.id,
                     "code": updated_code,
                     "maxUsesNumber": 17,
                     "maxUsesPerUser": 12,
@@ -150,7 +150,7 @@ def test_coupon_create_update_delete(make_promotion, coupon_ops: CouponOperation
         coupon_ops.delete(coupon_id)
 
     with allure.step("POST /coupons/search — verify coupon is gone"):
-        post = coupon_ops.search(promotion_id=promo["id"])
+        post = coupon_ops.search(promotion_id=promo.id)
         post_results = post.get("results", []) if isinstance(post, dict) else post or []
         assert not any(c.get("id") == coupon_id for c in post_results), "Deleted coupon still visible in search"
 
@@ -163,10 +163,10 @@ def test_coupon_create_search_delete(make_promotion, coupon_ops: CouponOperation
     coupon_code = f"QA-COUPON-{uuid.uuid4().hex[:6].upper()}"
 
     with allure.step("POST /api/marketing/promotions/coupons/add"):
-        coupon_ops.add([{"promotionId": promo["id"], "code": coupon_code, "maxUsesNumber": 10}])
+        coupon_ops.add([{"promotionId": promo.id, "code": coupon_code, "maxUsesNumber": 10}])
 
     with allure.step("POST /api/marketing/promotions/coupons/search"):
-        search = coupon_ops.search(promotion_id=promo["id"])
+        search = coupon_ops.search(promotion_id=promo.id)
         coupons = search.get("results", []) if isinstance(search, dict) else search or []
         found = next((c for c in coupons if c.get("code") == coupon_code), None)
         assert found is not None, f"Coupon {coupon_code} not found"
@@ -183,10 +183,10 @@ def test_promo_create_test_data(make_promotion, coupon_ops: CouponOperations, pr
     coupon_code = f"QA-DATA-{uuid.uuid4().hex[:6].upper()}"
 
     with allure.step("Add coupon to promotion"):
-        coupon_ops.add([{"promotionId": promo["id"], "code": coupon_code, "maxUsesNumber": 5}])
+        coupon_ops.add([{"promotionId": promo.id, "code": coupon_code, "maxUsesNumber": 5}])
 
     with allure.step("Verify promotion has coupon"):
-        search = coupon_ops.search(promotion_id=promo["id"])
+        search = coupon_ops.search(promotion_id=promo.id)
         coupons = search.get("results", []) if isinstance(search, dict) else search or []
         assert len(coupons) >= 1
 

--- a/tests/restapi/orders/conftest.py
+++ b/tests/restapi/orders/conftest.py
@@ -10,6 +10,7 @@ from core.clients.rest import RestClient
 from core.global_settings import GlobalSettings
 from restapi.constants import ORDER_LINE_ITEM_TEMPLATE, ORDER_TEMPLATE
 from restapi.operations import OrderOperations
+from restapi.types import CustomerOrder
 
 
 @pytest.fixture
@@ -31,7 +32,7 @@ def make_order(
     order_ops: OrderOperations,
     global_settings: GlobalSettings,
     seed_order_customer: dict,
-) -> Generator[Callable[..., dict], None, None]:
+) -> Generator[Callable[..., CustomerOrder], None, None]:
     """Factory: create a customer order; deletes everything created at teardown.
 
     Defaults produce an empty-items order suitable for basic CRUD/search tests.
@@ -40,7 +41,7 @@ def make_order(
     """
     created_ids: list[str] = []
 
-    def _make(*, with_item: bool = False, **overrides: Any) -> dict:
+    def _make(*, with_item: bool = False, **overrides: Any) -> CustomerOrder:
         items: list[dict] = []
         if with_item:
             line_item = {**copy.deepcopy(ORDER_LINE_ITEM_TEMPLATE), "id": str(uuid.uuid4())}
@@ -59,7 +60,7 @@ def make_order(
         payload.update(overrides)
 
         order = order_ops.create(payload)
-        created_ids.append(order["id"])
+        created_ids.append(order.id)
         return order
 
     yield _make

--- a/tests/restapi/orders/test_orders.py
+++ b/tests/restapi/orders/test_orders.py
@@ -44,9 +44,9 @@ def test_order_create(make_order) -> None:
         order = make_order()
 
     with allure.step("Verify response"):
-        assert order["id"]
-        assert order["number"].startswith("QA-")
-        assert order["status"] == "New"
+        assert order.id
+        assert order.number.startswith("QA-")
+        assert order.status == "New"
 
 
 # ---------------------------------------------------------------------- read
@@ -58,13 +58,13 @@ def test_order_create(make_order) -> None:
 def test_order_get_by_id(make_order, order_ops: OrderOperations) -> None:
     order = make_order()
 
-    with allure.step(f"GET /api/order/customerOrders/{order['id']}"):
-        reloaded = order_ops.get_by_id(order["id"])
+    with allure.step(f"GET /api/order/customerOrders/{order.id}"):
+        reloaded = order_ops.get_by_id(order.id)
 
     with allure.step("Verify fields match"):
-        assert reloaded["id"] == order["id"]
-        assert reloaded["number"] == order["number"]
-        assert reloaded["storeId"] == order["storeId"]
+        assert reloaded.id == order.id
+        assert reloaded.number == order.number
+        assert reloaded.store_id == order.store_id
 
 
 @pytest.mark.restapi
@@ -73,27 +73,32 @@ def test_order_get_by_id(make_order, order_ops: OrderOperations) -> None:
 def test_order_get_by_number(make_order, order_ops: OrderOperations) -> None:
     order = make_order()
 
-    with allure.step(f"GET /api/order/customerOrders/number/{order['number']}"):
-        reloaded = order_ops.get_by_number(order["number"])
+    with allure.step(f"GET /api/order/customerOrders/number/{order.number}"):
+        reloaded = order_ops.get_by_number(order.number)
 
     with allure.step("Verify the same order is returned"):
-        assert reloaded["id"] == order["id"]
-        assert reloaded["number"] == order["number"]
+        assert reloaded.id == order.id
+        assert reloaded.number == order.number
 
 
 @pytest.mark.restapi
 @allure.feature(_FEATURE)
 @allure.title("Get order by non-existent id — expect empty or 404")
 def test_order_get_not_found(order_ops: OrderOperations) -> None:
+    from pydantic import ValidationError
+
     bogus_id = f"qa-missing-{uuid.uuid4().hex}"
 
     with allure.step(f"GET /api/order/customerOrders/{bogus_id}"):
+        # Server returns either 404 (HTTPError) or 200 with null body (ValidationError
+        # because Pydantic can't construct a CustomerOrder from None). Both indicate
+        # "not found" — either is accepted.
         try:
-            result = order_ops.get_by_id(bogus_id)
+            order_ops.get_by_id(bogus_id)
         except HTTPError as exc:
             assert exc.response.status_code in (404, 204)
-        else:
-            assert result is None or not result, f"Expected empty body for missing id, got: {result!r}"
+        except ValidationError:
+            pass  # null body — also a "not found" signal
 
 
 # -------------------------------------------------------------------- search
@@ -117,13 +122,13 @@ def test_order_search(order_ops: OrderOperations) -> None:
 def test_order_search_by_keyword_finds_created(make_order, order_ops: OrderOperations) -> None:
     order = make_order()
 
-    with allure.step(f"POST /api/order/customerOrders/search keyword={order['number']}"):
-        result = order_ops.search(keyword=order["number"], take=5)
+    with allure.step(f"POST /api/order/customerOrders/search keyword={order.number}"):
+        result = order_ops.search(keyword=order.number, take=5)
 
     with allure.step("Verify created order is among results"):
         assert isinstance(result, dict)
         ids = [r.get("id") for r in (result.get("results") or [])]
-        assert order["id"] in ids, f"Order {order['id']} not found in search results: {ids}"
+        assert order.id in ids, f"Order {order.id} not found in search results: {ids}"
 
 
 @pytest.mark.restapi
@@ -148,12 +153,12 @@ def test_order_indexed_search_enabled(order_ops: OrderOperations) -> None:
 def test_order_get_new_payment(make_order, order_ops: OrderOperations) -> None:
     order = make_order(with_item=True)
 
-    with allure.step(f"GET /api/order/customerOrders/{order['id']}/payments/new"):
-        payment = order_ops.get_new_payment(order["id"])
+    with allure.step(f"GET /api/order/customerOrders/{order.id}/payments/new"):
+        payment = order_ops.get_new_payment(order.id)
 
     with allure.step("Verify payment is bound to order's customer"):
         assert isinstance(payment, dict)
-        assert payment.get("customerId") == order["customerId"]
+        assert payment.get("customerId") == order.customer_id
         assert payment.get("number")
 
 
@@ -163,8 +168,8 @@ def test_order_get_new_payment(make_order, order_ops: OrderOperations) -> None:
 def test_order_get_new_shipment(make_order, order_ops: OrderOperations) -> None:
     order = make_order(with_item=True)
 
-    with allure.step(f"GET /api/order/customerOrders/{order['id']}/shipments/new"):
-        shipment = order_ops.get_new_shipment(order["id"])
+    with allure.step(f"GET /api/order/customerOrders/{order.id}/shipments/new"):
+        shipment = order_ops.get_new_shipment(order.id)
 
     with allure.step("Verify shipment has a generated number"):
         assert isinstance(shipment, dict)
@@ -181,11 +186,13 @@ def test_order_update_status(make_order, order_ops: OrderOperations) -> None:
     order = make_order()
 
     with allure.step("PUT /api/order/customerOrders — status=Processing"):
-        order_ops.update({**order, "status": "Processing"})
+        body = order.model_dump(by_alias=True)
+        body["status"] = "Processing"
+        order_ops.update(body)
 
     with allure.step("Verify status changed via GET"):
-        reloaded = order_ops.get_by_id(order["id"])
-        assert reloaded["status"] == "Processing"
+        reloaded = order_ops.get_by_id(order.id)
+        assert reloaded.status == "Processing"
 
 
 @pytest.mark.restapi
@@ -193,9 +200,9 @@ def test_order_update_status(make_order, order_ops: OrderOperations) -> None:
 @allure.title("Recalculate order totals after quantity change")
 def test_order_recalculate_updates_totals(make_order, order_ops: OrderOperations) -> None:
     order = make_order(with_item=True)
-    new_quantity = order["items"][0]["quantity"] + 1
-
-    body = {**order, "items": [{**order["items"][0], "quantity": new_quantity}]}
+    body = order.model_dump(by_alias=True)
+    new_quantity = body["items"][0]["quantity"] + 1
+    body["items"][0]["quantity"] = new_quantity
 
     with allure.step("PUT /api/order/customerOrders/recalculate"):
         recalculated = order_ops.recalculate(body)
@@ -212,18 +219,16 @@ def test_order_recalculate_updates_totals(make_order, order_ops: OrderOperations
 @allure.title("Attach generated payment + shipment, recalculate, update — verify persisted")
 def test_order_update_attaches_payment_and_shipment(make_order, order_ops: OrderOperations) -> None:
     order = make_order(with_item=True)
-    new_quantity = order["items"][0]["quantity"] + 1
+    body = order.model_dump(by_alias=True)
+    new_quantity = body["items"][0]["quantity"] + 1
 
     with allure.step("Generate fresh payment and shipment for the order"):
-        payment = order_ops.get_new_payment(order["id"])
-        shipment = order_ops.get_new_shipment(order["id"])
+        payment = order_ops.get_new_payment(order.id)
+        shipment = order_ops.get_new_shipment(order.id)
 
-    body = {
-        **order,
-        "inPayments": [payment],
-        "shipments": [shipment],
-        "items": [{**order["items"][0], "quantity": new_quantity}],
-    }
+    body["inPayments"] = [payment]
+    body["shipments"] = [shipment]
+    body["items"][0]["quantity"] = new_quantity
 
     with allure.step("PUT /api/order/customerOrders/recalculate"):
         recalculated = order_ops.recalculate(body)
@@ -231,11 +236,12 @@ def test_order_update_attaches_payment_and_shipment(make_order, order_ops: Order
     with allure.step("PUT /api/order/customerOrders — persist recalculated body"):
         order_ops.update(recalculated)
 
-    with allure.step(f"GET /api/order/customerOrders/number/{order['number']} — verify"):
-        updated = order_ops.get_by_number(order["number"])
-        assert updated["items"][0]["quantity"] == new_quantity
-        assert updated["inPayments"][0]["number"] == payment["number"]
-        assert updated["shipments"][0]["number"] == shipment["number"]
+    with allure.step(f"GET /api/order/customerOrders/number/{order.number} — verify"):
+        updated = order_ops.get_by_number(order.number)
+        assert updated.items[0].quantity == new_quantity
+        extras = updated.model_extra or {}
+        assert extras.get("inPayments", [{}])[0].get("number") == payment["number"]
+        assert extras.get("shipments", [{}])[0].get("number") == shipment["number"]
 
 
 # ----------------------------------------------------------- search changes
@@ -258,24 +264,21 @@ def test_order_search_changes_count_grows_after_update(make_order, order_ops: Or
     order = make_order(with_item=True)
 
     with allure.step("POST /api/order/customerOrders/searchChanges — initial count"):
-        initial = order_ops.search_changes(order_id=order["id"])
+        initial = order_ops.search_changes(order_id=order.id)
         initial_count = initial["totalCount"]
 
     with allure.step("Attach payment + shipment + bump quantity, recalculate, persist update"):
-        payment = order_ops.get_new_payment(order["id"])
-        shipment = order_ops.get_new_shipment(order["id"])
-        new_quantity = order["items"][0]["quantity"] + 1
-        body = {
-            **order,
-            "inPayments": [payment],
-            "shipments": [shipment],
-            "items": [{**order["items"][0], "quantity": new_quantity}],
-        }
+        payment = order_ops.get_new_payment(order.id)
+        shipment = order_ops.get_new_shipment(order.id)
+        body = order.model_dump(by_alias=True)
+        body["inPayments"] = [payment]
+        body["shipments"] = [shipment]
+        body["items"][0]["quantity"] = body["items"][0]["quantity"] + 1
         recalculated = order_ops.recalculate(body)
         order_ops.update(recalculated)
 
     with allure.step("POST /api/order/customerOrders/searchChanges — final count > initial"):
-        final = order_ops.search_changes(order_id=order["id"])
+        final = order_ops.search_changes(order_id=order.id)
         assert (
             final["totalCount"] > initial_count
         ), f"Expected change count to grow, got initial={initial_count} final={final['totalCount']}"
@@ -289,15 +292,15 @@ def test_order_search_changes_count_grows_after_update(make_order, order_ops: Or
 @allure.title("Delete order — search by its number returns nothing")
 def test_order_delete_removes_from_search(make_order, order_ops: OrderOperations) -> None:
     order = make_order()
-    order_number = order["number"]
+    order_number = order.number
 
-    with allure.step(f"DELETE /api/order/customerOrders?ids={order['id']}"):
-        order_ops.delete(order["id"])
+    with allure.step(f"DELETE /api/order/customerOrders?ids={order.id}"):
+        order_ops.delete(order.id)
 
     with allure.step(f"POST /api/order/customerOrders/search keyword={order_number} — expect deleted id absent"):
         result = order_ops.search(keyword=order_number, take=5)
         ids = [r.get("id") for r in (result.get("results") or [])]
-        assert order["id"] not in ids, f"Deleted order {order['id']} still appears in search"
+        assert order.id not in ids, f"Deleted order {order.id} still appears in search"
 
 
 # --------------------------------------------------------- input validation

--- a/tests/restapi/platform/conftest.py
+++ b/tests/restapi/platform/conftest.py
@@ -15,6 +15,7 @@ from restapi.operations import (
     SettingsOperations,
     UserOperations,
 )
+from restapi.types import Role
 
 
 @pytest.fixture
@@ -87,15 +88,15 @@ def make_user(
 @pytest.fixture
 def make_role(
     role_ops: RoleOperations,
-) -> Generator[Callable[..., dict], None, None]:
+) -> Generator[Callable[..., Role], None, None]:
     """Factory: creates a platform role, cleans up at teardown."""
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Role:
         suffix = uuid.uuid4().hex[:8]
         name = overrides.pop("name", f"QARole_{suffix}")
         role = role_ops.create(name=name, **overrides)
-        created_ids.append(role["id"])
+        created_ids.append(role.id)
         return role
 
     yield _make

--- a/tests/restapi/platform/test_api_key.py
+++ b/tests/restapi/platform/test_api_key.py
@@ -31,7 +31,7 @@ def test_api_key_create(make_user, user_ops: UserOperations, api_key_ops: ApiKey
     full_user = user_ops.get_by_name(user["user_name"])
 
     with allure.step("POST /api/platform/security/users/apikeys"):
-        key = _create_key_and_find(api_key_ops, full_user["id"], f"QAKey_{uuid.uuid4().hex[:8]}")
+        key = _create_key_and_find(api_key_ops, full_user.id, f"QAKey_{uuid.uuid4().hex[:8]}")
 
     with allure.step("Verify API key created"):
         assert key["id"]
@@ -47,10 +47,10 @@ def test_api_key_create(make_user, user_ops: UserOperations, api_key_ops: ApiKey
 def test_api_key_get_by_user(make_user, user_ops: UserOperations, api_key_ops: ApiKeyOperations) -> None:
     user = make_user()
     full_user = user_ops.get_by_name(user["user_name"])
-    key = _create_key_and_find(api_key_ops, full_user["id"], f"QAKey_{uuid.uuid4().hex[:8]}")
+    key = _create_key_and_find(api_key_ops, full_user.id, f"QAKey_{uuid.uuid4().hex[:8]}")
 
-    with allure.step(f"GET /api/platform/security/users/{full_user['id']}/apikeys"):
-        keys = api_key_ops.get_by_user_id(full_user["id"])
+    with allure.step(f"GET /api/platform/security/users/{full_user.id}/apikeys"):
+        keys = api_key_ops.get_by_user_id(full_user.id)
 
     with allure.step("Verify key found"):
         assert isinstance(keys, list)
@@ -66,13 +66,13 @@ def test_api_key_get_by_user(make_user, user_ops: UserOperations, api_key_ops: A
 def test_api_key_update(make_user, user_ops: UserOperations, api_key_ops: ApiKeyOperations) -> None:
     user = make_user()
     full_user = user_ops.get_by_name(user["user_name"])
-    key = _create_key_and_find(api_key_ops, full_user["id"], f"QAKey_{uuid.uuid4().hex[:8]}")
+    key = _create_key_and_find(api_key_ops, full_user.id, f"QAKey_{uuid.uuid4().hex[:8]}")
 
     with allure.step("PUT /api/platform/security/users/apikeys — isActive=false"):
         api_key_ops.update(key, isActive=False)
 
     with allure.step("Verify deactivated"):
-        keys = api_key_ops.get_by_user_id(full_user["id"])
+        keys = api_key_ops.get_by_user_id(full_user.id)
         updated = next((k for k in keys if k["id"] == key["id"]), None)
         assert updated is not None
         assert updated["isActive"] is False
@@ -87,11 +87,11 @@ def test_api_key_update(make_user, user_ops: UserOperations, api_key_ops: ApiKey
 def test_api_key_delete(make_user, user_ops: UserOperations, api_key_ops: ApiKeyOperations) -> None:
     user = make_user()
     full_user = user_ops.get_by_name(user["user_name"])
-    key = _create_key_and_find(api_key_ops, full_user["id"], f"QAKey_{uuid.uuid4().hex[:8]}")
+    key = _create_key_and_find(api_key_ops, full_user.id, f"QAKey_{uuid.uuid4().hex[:8]}")
 
     with allure.step(f"DELETE /api/platform/security/users/apikeys ids=[{key['id']}]"):
         api_key_ops.delete([key["id"]])
 
     with allure.step("Verify key removed"):
-        keys = api_key_ops.get_by_user_id(full_user["id"])
+        keys = api_key_ops.get_by_user_id(full_user.id)
         assert not any(k["id"] == key["id"] for k in keys)

--- a/tests/restapi/platform/test_roles.py
+++ b/tests/restapi/platform/test_roles.py
@@ -19,8 +19,8 @@ def test_role_create(make_role, role_ops: RoleOperations) -> None:
         role = make_role(permissions=[{"name": "security:call_api"}])
 
     with allure.step("Verify role created"):
-        assert role["id"]
-        assert role["name"].startswith("QARole_")
+        assert role.id
+        assert role.name.startswith("QARole_")
 
 
 @pytest.mark.restapi
@@ -29,12 +29,12 @@ def test_role_create(make_role, role_ops: RoleOperations) -> None:
 def test_role_get_by_name(make_role, role_ops: RoleOperations) -> None:
     role = make_role(permissions=[{"name": "security:call_api"}])
 
-    with allure.step(f"GET /api/platform/security/roles/{role['name']}"):
-        fetched = role_ops.get_by_name(role["name"])
+    with allure.step(f"GET /api/platform/security/roles/{role.name}"):
+        fetched = role_ops.get_by_name(role.name)
 
     with allure.step("Verify fields"):
-        assert fetched["id"] == role["id"]
-        assert fetched["name"] == role["name"]
+        assert fetched.id == role.id
+        assert fetched.name == role.name
 
 
 @pytest.mark.restapi
@@ -44,11 +44,11 @@ def test_role_search(make_role, role_ops: RoleOperations) -> None:
     role = make_role()
 
     with allure.step("POST /api/platform/security/roles/search"):
-        search = role_ops.search(keyword=role["name"])
+        search = role_ops.search(keyword=role.name)
 
     with allure.step("Verify role in results"):
         assert search.get("totalCount", 0) >= 1
-        found = next((r for r in search.get("results", []) if r["id"] == role["id"]), None)
+        found = next((r for r in search.get("results", []) if r["id"] == role.id), None)
         assert found is not None
 
 
@@ -63,8 +63,8 @@ def test_role_update(make_role, role_ops: RoleOperations) -> None:
         role_ops.update(role, description=new_desc)
 
     with allure.step("Verify update"):
-        fetched = role_ops.get_by_name(role["name"])
-        assert fetched["description"] == new_desc
+        fetched = role_ops.get_by_name(role.name)
+        assert (fetched.model_extra or {}).get("description") == new_desc
 
 
 @pytest.mark.restapi
@@ -73,13 +73,13 @@ def test_role_update(make_role, role_ops: RoleOperations) -> None:
 def test_role_delete(make_role, role_ops: RoleOperations) -> None:
     role = make_role()
 
-    with allure.step(f"DELETE /api/platform/security/roles?ids={role['id']}"):
-        role_ops.delete(role["id"])
+    with allure.step(f"DELETE /api/platform/security/roles?ids={role.id}"):
+        role_ops.delete(role.id)
 
     with allure.step("Verify role removed"):
-        search = role_ops.search(keyword=role["name"])
+        search = role_ops.search(keyword=role.name)
         ids = [r["id"] for r in search.get("results", [])]
-        assert role["id"] not in ids
+        assert role.id not in ids
 
 
 @pytest.mark.restapi
@@ -92,8 +92,8 @@ def test_role_remove_permission(make_role, role_ops: RoleOperations) -> None:
         role_ops.update(role, permissions=[{"name": "security:call_api"}])
 
     with allure.step("Verify permission removed"):
-        fetched = role_ops.get_by_name(role["name"])
-        perm_names = [p.get("name") for p in fetched.get("permissions", [])]
+        fetched = role_ops.get_by_name(role.name)
+        perm_names = [p.get("name") for p in (fetched.model_extra or {}).get("permissions", [])]
         assert "cache:reset" not in perm_names
         assert "security:call_api" in perm_names
 
@@ -130,19 +130,19 @@ def test_role_assign_to_user(
         assert provider.is_authenticated
         provider.sign_out()
 
-    with allure.step(f"PUT /api/platform/security/users — assign role '{role['name']}' to user"):
+    with allure.step(f"PUT /api/platform/security/users — assign role '{role.name}' to user"):
         full_user = user_ops.get_by_name(user["user_name"])
-        user_ops.update(full_user, roles=[{"id": role["id"], "name": role["name"]}])
+        user_ops.update(full_user, roles=[{"id": role.id, "name": role.name}])
 
     with allure.step("GET user — verify role present"):
         reloaded = user_ops.get_by_name(user["user_name"])
-        role_ids = [r.get("id") for r in reloaded.get("roles", [])]
-        assert role["id"] in role_ids, f"Role {role['id']} not in {role_ids}"
+        role_ids = [r.get("id") for r in (reloaded.model_extra or {}).get("roles", [])]
+        assert role.id in role_ids, f"Role {role.id} not in {role_ids}"
 
     with allure.step("Revoke role — update user with empty roles"):
         user_ops.update(reloaded, roles=[])
 
     with allure.step("GET user — verify role removed"):
         final = user_ops.get_by_name(user["user_name"])
-        final_role_ids = [r.get("id") for r in final.get("roles", [])]
-        assert role["id"] not in final_role_ids
+        final_role_ids = [r.get("id") for r in (final.model_extra or {}).get("roles", [])]
+        assert role.id not in final_role_ids

--- a/tests/restapi/platform/test_user.py
+++ b/tests/restapi/platform/test_user.py
@@ -76,7 +76,7 @@ def test_user_update(make_user, user_ops: UserOperations) -> None:
 
     with allure.step("Verify email updated via GET"):
         reloaded = user_ops.get_by_name(user["user_name"])
-        assert reloaded["email"] == new_email
+        assert reloaded.email == new_email
 
 
 @pytest.mark.restapi
@@ -105,12 +105,12 @@ def test_user_get_by_id(make_user, user_ops: UserOperations) -> None:
 
     with allure.step(f"GET /api/platform/security/users/{user['user_name']}"):
         full_user = user_ops.get_by_name(user["user_name"])
-        user_id = full_user["id"]
+        user_id = full_user.id
 
     with allure.step("Verify fields"):
-        assert full_user["userName"] == user["user_name"]
-        assert full_user["email"] == user["email"]
-        assert full_user["id"] == user_id
+        assert full_user.user_name == user["user_name"]
+        assert full_user.email == user["email"]
+        assert full_user.id == user_id
 
 
 @pytest.mark.restapi
@@ -123,8 +123,8 @@ def test_user_get_by_name(make_user, user_ops: UserOperations) -> None:
         full_user = user_ops.get_by_name(user["user_name"])
 
     with allure.step("Verify user type and name"):
-        assert full_user["userName"] == user["user_name"]
-        assert full_user["userType"] == "Manager"
+        assert full_user.user_name == user["user_name"]
+        assert full_user.user_type == "Manager"
 
 
 @pytest.mark.restapi

--- a/tests/restapi/platform/test_user_lock.py
+++ b/tests/restapi/platform/test_user_lock.py
@@ -19,8 +19,8 @@ def test_user_lock_unlock(make_user, user_ops: UserOperations, global_settings: 
     user = make_user()
     full_user = user_ops.get_by_name(user["user_name"])
 
-    with allure.step(f"POST /api/platform/security/users/{full_user['id']}/lock"):
-        user_ops.lock(full_user["id"])
+    with allure.step(f"POST /api/platform/security/users/{full_user.id}/lock"):
+        user_ops.lock(full_user.id)
 
     with allure.step("Verify login blocked (expect 400)"):
         response = requests.post(
@@ -35,8 +35,8 @@ def test_user_lock_unlock(make_user, user_ops: UserOperations, global_settings: 
         )
         assert response.status_code == 400, f"Expected 400 for locked user, got {response.status_code}"
 
-    with allure.step(f"POST /api/platform/security/users/{full_user['id']}/unlock"):
-        user_ops.unlock(full_user["id"])
+    with allure.step(f"POST /api/platform/security/users/{full_user.id}/unlock"):
+        user_ops.unlock(full_user.id)
 
     with allure.step("Verify login works after unlock"):
         provider = AuthProvider(global_settings)
@@ -81,16 +81,16 @@ def test_user_lock_api_key_inactive(
 
     with allure.step("Create API key then deactivate"):
         # POST returns empty body; diff before/after to find the new key
-        before_ids = {k["id"] for k in (api_key_ops_instance.get_by_user_id(full_user["id"]) or [])}
-        api_key_ops_instance.create(user_id=full_user["id"], name=f"QAKey_{uuid.uuid4().hex[:6]}")
-        after = api_key_ops_instance.get_by_user_id(full_user["id"]) or []
+        before_ids = {k["id"] for k in (api_key_ops_instance.get_by_user_id(full_user.id) or [])}
+        api_key_ops_instance.create(user_id=full_user.id, name=f"QAKey_{uuid.uuid4().hex[:6]}")
+        after = api_key_ops_instance.get_by_user_id(full_user.id) or []
         new_keys = [k for k in after if k["id"] not in before_ids]
         assert len(new_keys) == 1, f"Expected 1 new key, got {len(new_keys)}"
         key = new_keys[0]
         api_key_ops_instance.update(key, isActive=False)
 
     with allure.step("Verify deactivated key"):
-        keys = api_key_ops_instance.get_by_user_id(full_user["id"])
+        keys = api_key_ops_instance.get_by_user_id(full_user.id)
         updated = next((k for k in keys if k["id"] == key["id"]), None)
         assert updated is not None
         assert updated["isActive"] is False

--- a/tests/restapi/platform/test_user_password.py
+++ b/tests/restapi/platform/test_user_password.py
@@ -83,8 +83,8 @@ def test_user_send_verification_email(make_user, user_ops: UserOperations) -> No
     user = make_user()
     full_user = user_ops.get_by_name(user["user_name"])
 
-    with allure.step(f"POST /api/platform/security/users/{full_user['id']}/sendverificationemail"):
-        user_ops.send_verification_email(full_user["id"])
+    with allure.step(f"POST /api/platform/security/users/{full_user.id}/sendverificationemail"):
+        user_ops.send_verification_email(full_user.id)
     # No assertion on response body — endpoint returns 204/200 with no content.
     # The test verifies the endpoint doesn't error out.
 

--- a/tests/restapi/pricing/conftest.py
+++ b/tests/restapi/pricing/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from core.clients.rest import RestClient
 from restapi.operations import PricelistAssignmentOperations, PricelistOperations, PriceOperations
+from restapi.types import Pricelist, PricelistAssignment
 
 
 @pytest.fixture
@@ -25,13 +26,13 @@ def assignment_ops(rest_client: RestClient, backend_base_url: str) -> PricelistA
 
 
 @pytest.fixture
-def make_pricelist(pricelist_ops: PricelistOperations) -> Generator[Callable[..., dict], None, None]:
+def make_pricelist(pricelist_ops: PricelistOperations) -> Generator[Callable[..., Pricelist], None, None]:
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Pricelist:
         name = overrides.pop("name", f"QAPricelist_{uuid.uuid4().hex[:8]}")
         pricelist = pricelist_ops.create(name=name, **overrides)
-        created_ids.append(pricelist["id"])
+        created_ids.append(pricelist.id)
         return pricelist
 
     yield _make
@@ -46,22 +47,24 @@ def make_pricelist(pricelist_ops: PricelistOperations) -> Generator[Callable[...
 @pytest.fixture
 def make_assignment(
     assignment_ops: PricelistAssignmentOperations,
-    make_pricelist: Callable[..., dict],
+    make_pricelist: Callable[..., Pricelist],
     seed_catalog_id: str,
-) -> Generator[Callable[..., dict], None, None]:
+) -> Generator[Callable[..., PricelistAssignment], None, None]:
     created_ids: list[str] = []
 
-    def _make(*, pricelist: dict | None = None, catalog_id: str | None = None, **overrides: Any) -> dict:
+    def _make(
+        *, pricelist: Pricelist | None = None, catalog_id: str | None = None, **overrides: Any
+    ) -> PricelistAssignment:
         if pricelist is None:
             pricelist = make_pricelist()
         name = overrides.pop("name", f"QAAssign_{uuid.uuid4().hex[:8]}")
         assignment = assignment_ops.create(
-            pricelist_id=pricelist["id"],
+            pricelist_id=pricelist.id,
             catalog_id=catalog_id or seed_catalog_id,
             name=name,
             **overrides,
         )
-        created_ids.append(assignment["id"])
+        created_ids.append(assignment.id)
         return assignment
 
     yield _make

--- a/tests/restapi/pricing/test_assignments.py
+++ b/tests/restapi/pricing/test_assignments.py
@@ -27,8 +27,8 @@ def test_assignment_create(make_assignment) -> None:
         assignment = make_assignment()
 
     with allure.step("Verify response"):
-        assert assignment["id"]
-        assert assignment["name"].startswith("QAAssign_")
+        assert assignment.id
+        assert assignment.name.startswith("QAAssign_")
 
 
 @pytest.mark.restapi
@@ -36,14 +36,14 @@ def test_assignment_create(make_assignment) -> None:
 @allure.title("Update pricelist assignment")
 def test_assignment_update(make_assignment, assignment_ops: PricelistAssignmentOperations) -> None:
     assignment = make_assignment()
-    new_name = f"{assignment['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{assignment.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/pricing/assignments — name={new_name}"):
         assignment_ops.update(assignment, name=new_name)
 
     with allure.step("Verify update"):
-        reloaded = assignment_ops.get_by_id(assignment["id"])
-        assert reloaded["name"] == new_name
+        reloaded = assignment_ops.get_by_id(assignment.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -57,8 +57,8 @@ def test_assignment_update_alt(make_assignment, assignment_ops: PricelistAssignm
         assignment_ops.update(assignment, description=new_desc)
 
     with allure.step("Verify"):
-        reloaded = assignment_ops.get_by_id(assignment["id"])
-        assert reloaded.get("description") == new_desc
+        reloaded = assignment_ops.get_by_id(assignment.id)
+        assert (reloaded.model_extra or {}).get("description") == new_desc
 
 
 @pytest.mark.restapi
@@ -78,12 +78,12 @@ def test_assignment_get_new(assignment_ops: PricelistAssignmentOperations) -> No
 def test_assignment_get_by_id(make_assignment, assignment_ops: PricelistAssignmentOperations) -> None:
     assignment = make_assignment()
 
-    with allure.step(f"GET /api/pricing/assignments/{assignment['id']}"):
-        reloaded = assignment_ops.get_by_id(assignment["id"])
+    with allure.step(f"GET /api/pricing/assignments/{assignment.id}"):
+        reloaded = assignment_ops.get_by_id(assignment.id)
 
     with allure.step("Verify fields"):
-        assert reloaded["id"] == assignment["id"]
-        assert reloaded["name"] == assignment["name"]
+        assert reloaded.id == assignment.id
+        assert reloaded.name == assignment.name
 
 
 @pytest.mark.restapi
@@ -93,12 +93,12 @@ def test_assignment_search(make_pricelist, make_assignment, assignment_ops: Pric
     pricelist = make_pricelist()
     assignment = make_assignment(pricelist=pricelist)
 
-    with allure.step(f"GET /api/pricing/assignments?pricelistIds={pricelist['id']}"):
-        result = assignment_ops.search(pricelist_id=pricelist["id"])
+    with allure.step(f"GET /api/pricing/assignments?pricelistIds={pricelist.id}"):
+        result = assignment_ops.search(pricelist_id=pricelist.id)
 
     with allure.step("Verify assignment in results"):
         items = result if isinstance(result, list) else result.get("results", [])
-        found = next((r for r in items if r["id"] == assignment["id"]), None)
+        found = next((r for r in items if r["id"] == assignment.id), None)
         assert found is not None
 
 
@@ -108,10 +108,10 @@ def test_assignment_search(make_pricelist, make_assignment, assignment_ops: Pric
 def test_assignment_delete(assignment_ops: PricelistAssignmentOperations, make_pricelist, seed_catalog_id: str) -> None:
     pricelist = make_pricelist()
     name = f"QADelAssign_{uuid.uuid4().hex[:8]}"
-    assignment = assignment_ops.create(pricelist_id=pricelist["id"], catalog_id=seed_catalog_id, name=name)
+    assignment = assignment_ops.create(pricelist_id=pricelist.id, catalog_id=seed_catalog_id, name=name)
 
-    with allure.step(f"DELETE /api/pricing/assignments?ids={assignment['id']}"):
-        assignment_ops.delete(assignment["id"])
+    with allure.step(f"DELETE /api/pricing/assignments?ids={assignment.id}"):
+        assignment_ops.delete(assignment.id)
 
 
 @pytest.mark.restapi
@@ -122,7 +122,7 @@ def test_assignment_delete_filtered(
 ) -> None:
     pricelist = make_pricelist()
     unique = f"QAFiltered_{uuid.uuid4().hex[:8]}"
-    assignment_ops.create(pricelist_id=pricelist["id"], catalog_id=seed_catalog_id, name=unique)
+    assignment_ops.create(pricelist_id=pricelist.id, catalog_id=seed_catalog_id, name=unique)
 
     with allure.step(f"DELETE /api/pricing/filteredAssignments?SearchPhrase={unique}"):
         assignment_ops.delete_filtered(unique)

--- a/tests/restapi/pricing/test_pricelist.py
+++ b/tests/restapi/pricing/test_pricelist.py
@@ -26,9 +26,9 @@ def test_pricelist_create(make_pricelist) -> None:
         pricelist = make_pricelist()
 
     with allure.step("Verify response"):
-        assert pricelist["id"]
-        assert pricelist["name"].startswith("QAPricelist_")
-        assert pricelist["currency"] == "USD"
+        assert pricelist.id
+        assert pricelist.name.startswith("QAPricelist_")
+        assert pricelist.currency == "USD"
 
 
 @pytest.mark.restapi
@@ -36,14 +36,14 @@ def test_pricelist_create(make_pricelist) -> None:
 @allure.title("Update pricelist — rename")
 def test_pricelist_update(make_pricelist, pricelist_ops: PricelistOperations) -> None:
     pricelist = make_pricelist()
-    new_name = f"{pricelist['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{pricelist.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/pricing/pricelists — name={new_name}"):
         pricelist_ops.update(pricelist, name=new_name)
 
     with allure.step("Verify update"):
-        reloaded = pricelist_ops.get_by_id(pricelist["id"])
-        assert reloaded["name"] == new_name
+        reloaded = pricelist_ops.get_by_id(pricelist.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -52,12 +52,12 @@ def test_pricelist_update(make_pricelist, pricelist_ops: PricelistOperations) ->
 def test_pricelist_search(make_pricelist, pricelist_ops: PricelistOperations) -> None:
     pricelist = make_pricelist()
 
-    with allure.step(f"GET /api/pricing/pricelists?keyword={pricelist['name']}"):
-        result = pricelist_ops.search(keyword=pricelist["name"])
+    with allure.step(f"GET /api/pricing/pricelists?keyword={pricelist.name}"):
+        result = pricelist_ops.search(keyword=pricelist.name)
 
     with allure.step("Verify in results"):
         items = result if isinstance(result, list) else result.get("results", [])
-        found = next((r for r in items if r["id"] == pricelist["id"]), None)
+        found = next((r for r in items if r["id"] == pricelist.id), None)
         assert found is not None
 
 
@@ -67,12 +67,12 @@ def test_pricelist_search(make_pricelist, pricelist_ops: PricelistOperations) ->
 def test_pricelist_get_by_id(make_pricelist, pricelist_ops: PricelistOperations) -> None:
     pricelist = make_pricelist()
 
-    with allure.step(f"GET /api/pricing/pricelists/{pricelist['id']}"):
-        reloaded = pricelist_ops.get_by_id(pricelist["id"])
+    with allure.step(f"GET /api/pricing/pricelists/{pricelist.id}"):
+        reloaded = pricelist_ops.get_by_id(pricelist.id)
 
     with allure.step("Verify fields"):
-        assert reloaded["id"] == pricelist["id"]
-        assert reloaded["name"] == pricelist["name"]
+        assert reloaded.id == pricelist.id
+        assert reloaded.name == pricelist.name
 
 
 @pytest.mark.restapi
@@ -94,14 +94,14 @@ def test_pricelist_delete(pricelist_ops: PricelistOperations) -> None:
     name = f"QADelPL_{uuid.uuid4().hex[:8]}"
     pricelist = pricelist_ops.create(name=name)
 
-    with allure.step(f"DELETE /api/pricing/pricelists?ids={pricelist['id']}"):
-        pricelist_ops.delete(pricelist["id"])
+    with allure.step(f"DELETE /api/pricing/pricelists?ids={pricelist.id}"):
+        pricelist_ops.delete(pricelist.id)
 
     with allure.step("Verify deleted"):
         result = pricelist_ops.search(keyword=name)
         items = result if isinstance(result, list) else result.get("results", [])
         ids = [r["id"] for r in items]
-        assert pricelist["id"] not in ids
+        assert pricelist.id not in ids
 
 
 @pytest.mark.restapi
@@ -118,7 +118,7 @@ def test_pricelist_add_products(make_pricelist, price_ops: PriceOperations, data
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 99.99,
                     "minQuantity": 1,
@@ -128,4 +128,4 @@ def test_pricelist_add_products(make_pricelist, price_ops: PriceOperations, data
         )
 
     with allure.step("Cleanup"):
-        price_ops.delete_by_pricelist_and_product(pricelist["id"], pid)
+        price_ops.delete_by_pricelist_and_product(pricelist.id, pid)

--- a/tests/restapi/pricing/test_prices.py
+++ b/tests/restapi/pricing/test_prices.py
@@ -42,7 +42,7 @@ def test_price_add_to_product(make_pricelist, price_ops: PriceOperations, datase
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 49.99,
                     "minQuantity": 1,
@@ -52,7 +52,7 @@ def test_price_add_to_product(make_pricelist, price_ops: PriceOperations, datase
         )
 
     with allure.step("Cleanup"):
-        price_ops.delete_by_pricelist_and_product(pricelist["id"], pid)
+        price_ops.delete_by_pricelist_and_product(pricelist.id, pid)
 
 
 @pytest.mark.restapi
@@ -66,7 +66,7 @@ def test_price_update(make_pricelist, price_ops: PriceOperations, dataset: dict)
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 10.00,
                     "minQuantity": 1,
@@ -79,7 +79,7 @@ def test_price_update(make_pricelist, price_ops: PriceOperations, dataset: dict)
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 25.00,
                     "minQuantity": 1,
@@ -89,7 +89,7 @@ def test_price_update(make_pricelist, price_ops: PriceOperations, dataset: dict)
         )
 
     with allure.step("Cleanup"):
-        price_ops.delete_by_pricelist_and_product(pricelist["id"], pid)
+        price_ops.delete_by_pricelist_and_product(pricelist.id, pid)
 
 
 @pytest.mark.restapi
@@ -98,8 +98,8 @@ def test_price_update(make_pricelist, price_ops: PriceOperations, dataset: dict)
 def test_price_search_get(make_pricelist, price_ops: PriceOperations) -> None:
     pricelist = make_pricelist()
 
-    with allure.step(f"GET /api/catalog/products/prices/search?pricelistId={pricelist['id']}"):
-        result = price_ops.search_get(pricelist_id=pricelist["id"])
+    with allure.step(f"GET /api/catalog/products/prices/search?pricelistId={pricelist.id}"):
+        result = price_ops.search_get(pricelist_id=pricelist.id)
 
     with allure.step("Verify response"):
         assert result is not None
@@ -112,7 +112,7 @@ def test_price_search_post(make_pricelist, price_ops: PriceOperations) -> None:
     pricelist = make_pricelist()
 
     with allure.step("POST /api/catalog/products/prices/search"):
-        result = price_ops.search_post(pricelist_ids=[pricelist["id"]])
+        result = price_ops.search_post(pricelist_ids=[pricelist.id])
 
     with allure.step("Verify response"):
         assert result is not None
@@ -129,7 +129,7 @@ def test_price_delete_by_id(make_pricelist, price_ops: PriceOperations, dataset:
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 5.00,
                     "minQuantity": 1,
@@ -139,7 +139,7 @@ def test_price_delete_by_id(make_pricelist, price_ops: PriceOperations, dataset:
         )
 
     with allure.step("Find price id via search"):
-        result = price_ops.search_post(pricelist_ids=[pricelist["id"]])
+        result = price_ops.search_post(pricelist_ids=[pricelist.id])
         prices = result.get("results", []) if isinstance(result, dict) else result or []
         price_ids = [p["id"] for p in prices if p.get("id")]
         if price_ids:
@@ -158,7 +158,7 @@ def test_price_delete_by_product(make_pricelist, price_ops: PriceOperations, dat
         price_ops.add_prices(
             [
                 {
-                    "priceListId": pricelist["id"],
+                    "priceListId": pricelist.id,
                     "productId": pid,
                     "list": 7.50,
                     "minQuantity": 1,
@@ -167,8 +167,8 @@ def test_price_delete_by_product(make_pricelist, price_ops: PriceOperations, dat
             ]
         )
 
-    with allure.step(f"DELETE /api/pricing/pricelists/{pricelist['id']}/products/prices?productIds={pid}"):
-        price_ops.delete_by_pricelist_and_product(pricelist["id"], pid)
+    with allure.step(f"DELETE /api/pricing/pricelists/{pricelist.id}/products/prices?productIds={pid}"):
+        price_ops.delete_by_pricelist_and_product(pricelist.id, pid)
 
 
 @pytest.mark.restapi
@@ -185,13 +185,13 @@ def test_price_add_delete_bulk(make_pricelist, price_ops: PriceOperations, datas
     with allure.step("Add bulk prices"):
         price_ops.add_prices(
             [
-                {"priceListId": pricelist["id"], "productId": pid1, "list": 1.00, "minQuantity": 1, "currency": "USD"},
-                {"priceListId": pricelist["id"], "productId": pid2, "list": 2.00, "minQuantity": 1, "currency": "USD"},
+                {"priceListId": pricelist.id, "productId": pid1, "list": 1.00, "minQuantity": 1, "currency": "USD"},
+                {"priceListId": pricelist.id, "productId": pid2, "list": 2.00, "minQuantity": 1, "currency": "USD"},
             ]
         )
 
     with allure.step("Delete by pricelist+product"):
-        price_ops.delete_by_pricelist_and_product(pricelist["id"], pid1, pid2)
+        price_ops.delete_by_pricelist_and_product(pricelist.id, pid1, pid2)
 
 
 @pytest.mark.restapi

--- a/tests/restapi/store/conftest.py
+++ b/tests/restapi/store/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from core.clients.rest import RestClient
 from restapi.operations import StoreOperations
+from restapi.types import Store
 
 
 @pytest.fixture
@@ -15,13 +16,13 @@ def store_ops(rest_client: RestClient, backend_base_url: str) -> StoreOperations
 
 
 @pytest.fixture
-def make_store(store_ops: StoreOperations) -> Generator[Callable[..., dict], None, None]:
+def make_store(store_ops: StoreOperations) -> Generator[Callable[..., Store], None, None]:
     created_ids: list[str] = []
 
-    def _make(**overrides: Any) -> dict:
+    def _make(**overrides: Any) -> Store:
         name = overrides.pop("name", f"QAStore_{uuid.uuid4().hex[:8]}")
         store = store_ops.create(name=name, **overrides)
-        created_ids.append(store["id"])
+        created_ids.append(store.id)
         return store
 
     yield _make

--- a/tests/restapi/store/test_store.py
+++ b/tests/restapi/store/test_store.py
@@ -29,8 +29,8 @@ def test_store_create(make_store) -> None:
         store = make_store()
 
     with allure.step("Verify response"):
-        assert store["id"]
-        assert store["name"].startswith("QAStore_")
+        assert store.id
+        assert store.name.startswith("QAStore_")
 
 
 @pytest.mark.restapi
@@ -41,8 +41,8 @@ def test_store_create_name_validation(store_ops: StoreOperations) -> None:
         try:
             store = store_ops.create(name="")
             # If it succeeds, clean up
-            if store and store.get("id"):
-                store_ops.delete(store["id"])
+            if store and store.id:
+                store_ops.delete(store.id)
         except Exception:
             pass  # Expected: validation error or 400
 
@@ -53,12 +53,12 @@ def test_store_create_name_validation(store_ops: StoreOperations) -> None:
 def test_store_get_by_id(make_store, store_ops: StoreOperations) -> None:
     store = make_store()
 
-    with allure.step(f"GET /api/stores/{store['id']}"):
-        reloaded = store_ops.get_by_id(store["id"])
+    with allure.step(f"GET /api/stores/{store.id}"):
+        reloaded = store_ops.get_by_id(store.id)
 
     with allure.step("Verify fields"):
-        assert reloaded["id"] == store["id"]
-        assert reloaded["name"] == store["name"]
+        assert reloaded.id == store.id
+        assert reloaded.name == store.name
 
 
 @pytest.mark.restapi
@@ -80,11 +80,11 @@ def test_store_search(make_store, store_ops: StoreOperations) -> None:
     store = make_store()
 
     with allure.step("POST /api/stores/search"):
-        result = store_ops.search(keyword=store["name"])
+        result = store_ops.search(keyword=store.name)
 
     with allure.step("Verify in results"):
         items = result.get("results", []) if isinstance(result, dict) else result or []
-        found = next((s for s in items if s["id"] == store["id"]), None)
+        found = next((s for s in items if s["id"] == store.id), None)
         assert found is not None
 
 
@@ -93,14 +93,14 @@ def test_store_search(make_store, store_ops: StoreOperations) -> None:
 @allure.title("Update store — rename")
 def test_store_update(make_store, store_ops: StoreOperations) -> None:
     store = make_store()
-    new_name = f"{store['name']}_UPD_{uuid.uuid4().hex[:4]}"
+    new_name = f"{store.name}_UPD_{uuid.uuid4().hex[:4]}"
 
     with allure.step(f"PUT /api/stores — name={new_name}"):
         store_ops.update(store, name=new_name)
 
     with allure.step("Verify update"):
-        reloaded = store_ops.get_by_id(store["id"])
-        assert reloaded["name"] == new_name
+        reloaded = store_ops.get_by_id(store.id)
+        assert reloaded.name == new_name
 
 
 @pytest.mark.restapi
@@ -111,26 +111,26 @@ def test_store_full_cycle(store_ops: StoreOperations) -> None:
 
     with allure.step("Create"):
         store = store_ops.create(name=name)
-        assert store["id"]
+        assert store.id
 
     with allure.step("Get"):
-        fetched = store_ops.get_by_id(store["id"])
-        assert fetched["name"] == name
+        fetched = store_ops.get_by_id(store.id)
+        assert fetched.name == name
 
     with allure.step("Update"):
         new_name = f"{name}_updated"
         store_ops.update(fetched, name=new_name)
-        updated = store_ops.get_by_id(store["id"])
-        assert updated["name"] == new_name
+        updated = store_ops.get_by_id(store.id)
+        assert updated.name == new_name
 
     with allure.step("Search"):
         result = store_ops.search(keyword=new_name)
         items = result.get("results", []) if isinstance(result, dict) else result or []
-        found = next((s for s in items if s["id"] == store["id"]), None)
+        found = next((s for s in items if s["id"] == store.id), None)
         assert found is not None
 
     with allure.step("Delete"):
-        store_ops.delete(store["id"])
+        store_ops.delete(store.id)
 
 
 @pytest.mark.restapi
@@ -139,8 +139,8 @@ def test_store_full_cycle(store_ops: StoreOperations) -> None:
 def test_store_delete(store_ops: StoreOperations) -> None:
     store = store_ops.create(name=f"QADelStore_{uuid.uuid4().hex[:8]}")
 
-    with allure.step(f"DELETE /api/stores?ids={store['id']}"):
-        store_ops.delete(store["id"])
+    with allure.step(f"DELETE /api/stores?ids={store.id}"):
+        store_ops.delete(store.id)
 
 
 @pytest.mark.restapi
@@ -173,4 +173,4 @@ def test_store_assets(store_ops: StoreOperations, dataset: dict) -> None:
 
     with allure.step("Verify store returned"):
         assert store is not None
-        assert store["id"] == store_id
+        assert store.id == store_id


### PR DESCRIPTION
…log vertical slice

Lays the foundation for typed REST responses (C3 in CODE_REVIEW.md), with Catalog as the first end-to-end migration. Establishes the pattern for follow-up entity migrations.

Foundation
- restapi/types/{__init__.py, base.py} — `RestModel` base mirroring gql/types/GqlModel: snake_case fields, to_camel aliasing, populate_by_name=True, extra="ignore" so unknown server fields are dropped silently.
- restapi/types/{catalog,category,product,user,role,order}.py — conservative hand-written models covering only the fields the test suite actually touches. Field set sourced from grep across tests/restapi/. Future direction (out of scope here): codegen from the platform's OpenAPI schema.

Catalog vertical slice (the demo)
- restapi/operations/catalog_operations.py — `create()` and `update()` now return `Catalog` (model_validate on the wire response). `search()` still returns dict (response shape needs a separate SearchResult model — defer). `update()` accepts the typed model and dumps via model_dump(by_alias=True).
- tests/restapi/catalog/conftest.py — `make_catalog` factory now returns `Catalog`. `make_category` accepts either `catalog: Catalog` or `catalog_id: str` (the latter for cases where you only have an id).
- tests/restapi/catalog/test_catalog.py — full sweep from `catalog["id"]` to `catalog.id`, etc.
- tests/restapi/catalog/test_category.py — fixed test_category_nested to pass `catalog_id=` instead of the previous `catalog={"id": ...}` hack.
- tests/restapi/catalog/test_product.py — `target_catalog["id"]` → `target_catalog.id` in the move_to_catalog test.

Verified
- 30/30 catalog tests pass on vcptcore-demo
- pytest --collect-only clean
- pyright errors on catalog_operations.py: 3 → 1 (the remaining one is search() returning dict, deferred)

Deferred to follow-up PRs (one per entity, mechanical pattern repeat)
- Category, Product, User, Role, Order operation+consumer migrations. Models are already in place; each follow-up just updates the operation to model_validate() and sweeps test consumers to attribute access.
- The 5 remaining entities will lift the bulk of the 129 reportReturnType pyright errors surfaced by C2 in the previous PR.