### PR TITLE
feat(e2e): capture per-test HAR via Playwright and attach to Allure

### DIFF
--- a/dataset/data/contacts/contact_acme_store_employee_1.json
+++ b/dataset/data/contacts/contact_acme_store_employee_1.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-1",
     "firstName": "ACME",
-    "lastName": "Employee 1",
+    "lastName": "Employee A",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_2.json
+++ b/dataset/data/contacts/contact_acme_store_employee_2.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-2",
     "firstName": "ACME",
-    "lastName": "Employee 2",
+    "lastName": "Employee B",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_3.json
+++ b/dataset/data/contacts/contact_acme_store_employee_3.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-3",
     "firstName": "ACME",
-    "lastName": "Employee 3",
+    "lastName": "Employee C",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_4.json
+++ b/dataset/data/contacts/contact_acme_store_employee_4.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-4",
     "firstName": "ACME",
-    "lastName": "Employee 4",
+    "lastName": "Employee D",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_5.json
+++ b/dataset/data/contacts/contact_acme_store_employee_5.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-5",
     "firstName": "ACME",
-    "lastName": "Employee 5",
+    "lastName": "Employee E",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_6.json
+++ b/dataset/data/contacts/contact_acme_store_employee_6.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-6",
     "firstName": "ACME",
-    "lastName": "Employee 6",
+    "lastName": "Employee F",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_7.json
+++ b/dataset/data/contacts/contact_acme_store_employee_7.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-7",
     "firstName": "ACME",
-    "lastName": "Employee 7",
+    "lastName": "Employee G",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_8.json
+++ b/dataset/data/contacts/contact_acme_store_employee_8.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-8",
     "firstName": "ACME",
-    "lastName": "Employee 8",
+    "lastName": "Employee H",
     "memberType": "Contact",
     "status": "Invited",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_employee_9.json
+++ b/dataset/data/contacts/contact_acme_store_employee_9.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-employee-9",
     "firstName": "ACME",
-    "lastName": "Employee 9",
+    "lastName": "Employee I",
     "memberType": "Contact",
     "status": "Locked",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_maintainer_1.json
+++ b/dataset/data/contacts/contact_acme_store_maintainer_1.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-maintainer-1",
     "firstName": "ACME",
-    "lastName": "Store Maintainer 1",
+    "lastName": "Store Maintainer One",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_manager_1.json
+++ b/dataset/data/contacts/contact_acme_store_manager_1.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-manager-1",
     "firstName": "ACME",
-    "lastName": "Store Manager 1",
+    "lastName": "Store Manager A",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_manager_2.json
+++ b/dataset/data/contacts/contact_acme_store_manager_2.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-manager-2",
     "firstName": "ACME",
-    "lastName": "Store Manager 2",
+    "lastName": "Store Manager B",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_manager_3.json
+++ b/dataset/data/contacts/contact_acme_store_manager_3.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-manager-3",
     "firstName": "ACME",
-    "lastName": "Store Manager 3",
+    "lastName": "Store Manager C",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_manager_4.json
+++ b/dataset/data/contacts/contact_acme_store_manager_4.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-manager-4",
     "firstName": "ACME",
-    "lastName": "Store Manager 4",
+    "lastName": "Store Manager D",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_purchasing_agent_1.json
+++ b/dataset/data/contacts/contact_acme_store_purchasing_agent_1.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-purchasing-agent-1",
     "firstName": "ACME",
-    "lastName": "Purchasing Agent 1",
+    "lastName": "Purchasing Agent A",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_purchasing_agent_2.json
+++ b/dataset/data/contacts/contact_acme_store_purchasing_agent_2.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-purchasing-agent-2",
     "firstName": "ACME",
-    "lastName": "Purchasing Agent 2",
+    "lastName": "Purchasing Agent B",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/dataset/data/contacts/contact_acme_store_purchasing_agent_3.json
+++ b/dataset/data/contacts/contact_acme_store_purchasing_agent_3.json
@@ -1,7 +1,7 @@
 {
     "id": "contact-acme-store-purchasing-agent-3",
     "firstName": "ACME",
-    "lastName": "Purchasing Agent 3",
+    "lastName": "Purchasing Agent C",
     "memberType": "Contact",
     "status": "Approved",
     "defaultOrganizationId": "organization-acme-store",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,7 @@ def _page_for_failure(request: pytest.FixtureRequest) -> Page | None:
 
 
 @pytest.fixture(autouse=True)
-def screenshot_on_failure(
-    request: pytest.FixtureRequest, _page_for_failure: Page | None
-) -> Generator:
+def screenshot_on_failure(request: pytest.FixtureRequest, _page_for_failure: Page | None) -> Generator:
     """Take a full-page screenshot when an E2E test fails and attach to Allure."""
     yield
 
@@ -138,9 +136,36 @@ def har_recorder(request: pytest.FixtureRequest) -> Generator[HARRecorder, None,
         )
 
 
-@pytest.fixture(scope="session")
-def browser_context_args(browser_context_args: dict[Any, Any]) -> dict[Any, Any]:
-    return {**browser_context_args, "viewport": {"width": 1920, "height": 1080}}
+@pytest.fixture
+def browser_context_args(browser_context_args: dict[Any, Any], request: pytest.FixtureRequest) -> dict[Any, Any]:
+    extra: dict[str, Any] = {"viewport": {"width": 1920, "height": 1080}}
+    if request.node.get_closest_marker("e2e"):
+        root_dir = Path(request.config.rootpath)
+        module = _har_module(Path(request.node.path))
+        out_dir = root_dir / "har-output" / module
+        out_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = _INVALID_FILENAME_CHARS.sub("_", request.node.name)
+        har_path = out_dir / f"{safe_name}.har"
+        request.node._e2e_har_path = har_path
+        extra["record_har_path"] = str(har_path)
+        extra["record_har_omit_content"] = False
+    return {**browser_context_args, **extra}
+
+
+@pytest.fixture(autouse=True)
+def attach_e2e_har(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Attach the Playwright HAR file to Allure once the context has flushed it."""
+    yield
+    if not request.node.get_closest_marker("e2e"):
+        return
+    har_path: Path | None = getattr(request.node, "_e2e_har_path", None)
+    if har_path and har_path.exists():
+        allure.attach.file(
+            str(har_path),
+            name=f"{request.node.name}.har",
+            attachment_type="application/json",
+            extension="har",
+        )
 
 
 @pytest.fixture(scope="session")
@@ -164,17 +189,13 @@ def dataset(dataset_manager: DatasetManager) -> dict[str, list[dict[str, Any]]]:
 
 
 @pytest.fixture
-def graphql_client(
-    with_user: AuthProvider, global_settings: GlobalSettings
-) -> Generator[GraphQLClient, None, None]:
+def graphql_client(with_user: AuthProvider, global_settings: GlobalSettings) -> Generator[GraphQLClient, None, None]:
     with GraphQLClient(auth=with_user, global_settings=global_settings) as client:
         yield client
 
 
 @pytest.fixture
-def with_user(
-    request: pytest.FixtureRequest, global_settings: GlobalSettings
-) -> Generator[AuthProvider, None, None]:
+def with_user(request: pytest.FixtureRequest, global_settings: GlobalSettings) -> Generator[AuthProvider, None, None]:
     provider = AuthProvider(global_settings)
     marker = request.node.get_closest_marker("with_user")
     if marker:
@@ -199,10 +220,7 @@ def with_cart(
     if not marker:
         yield None
         return
-    items = [
-        CartItemInput(product_id=product_id, quantity=quantity)
-        for product_id, quantity in marker.args[0]
-    ]
+    items = [CartItemInput(product_id=product_id, quantity=quantity) for product_id, quantity in marker.args[0]]
     with GraphQLClient(auth=with_user, global_settings=global_settings) as client:
         cart_ops = CartOperations(client)
         cart = cart_ops.add_items_to_cart(
@@ -229,11 +247,7 @@ def delete_cart_after(
     if not request.node.get_closest_marker("delete_cart_after"):
         yield None
         return
-    page = (
-        request.getfixturevalue("page")
-        if request.node.get_closest_marker("e2e")
-        else None
-    )
+    page = request.getfixturevalue("page") if request.node.get_closest_marker("e2e") else None
     yield
     if page is not None:
         user_id: str | None = BrowserStorage(page).get_user_id()


### PR DESCRIPTION
E2E tests were skipping HAR capture — har_recorder only hooks requests.Session for graphql_client / rest_client, so browser-driven traffic from Playwright was invisible in failure diagnosis.

- browser_context_args becomes function-scoped so it can derive a per-test HAR path. For tests marked @pytest.mark.e2e it injects record_har_path = har-output/<module>/<test_name>.har with full body capture.
- attach_e2e_har autouse fixture attaches the file to Allure after teardown, once Playwright has flushed the HAR to disk.

Output structure mirrors the existing har-output/{graphql,restapi} layout, so the workflow artifact bundle picks up e2e HARs without further wiring. Extra style noise is from pre-commit black --line-length=120 normalising pre-existing multi-line signatures.