### PR TITLE
fix(e2e): replace timing flakes with response-based waits and resilie…

### DIFF
--- a/tests/e2e/test_cart_item_update.py
+++ b/tests/e2e/test_cart_item_update.py
@@ -1,12 +1,17 @@
 import pytest
 from core.global_settings import GlobalSettings
 from page_objects.pages import CartPage
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Response, expect
 
 _PRODUCT_ID = "smartphone-samsung-galaxy-a57-5g"
 _ORIGINAL_QUANTITY = 3
 _UPDATED_QUANTITY = 4
 _USERNAME = "acme_store_employee_1@acme.com"
+
+
+def _is_cart_mutation(response: Response) -> bool:
+    post = response.request.post_data
+    return bool(post and "/graphql" in response.url and "mutation" in post)
 
 
 @pytest.mark.e2e
@@ -20,11 +25,10 @@ def test_cart_item_update_stepper(global_settings: GlobalSettings, page: Page) -
     line_item = cart_page.find_line_item(sku=_PRODUCT_ID)
     expect(line_item.root).to_be_visible()
     expect(line_item.quantity_stepper.root).to_be_visible()
-    expect(line_item.quantity_stepper.quantity_input).to_have_value(
-        str(_ORIGINAL_QUANTITY)
-    )
+    expect(line_item.quantity_stepper.quantity_input).to_have_value(str(_ORIGINAL_QUANTITY))
 
-    line_item.quantity_stepper.increment_button.click()
+    with page.expect_response(_is_cart_mutation):
+        line_item.quantity_stepper.increment_button.click()
     expect(cart_page.cart_quantity_label).to_have_text(str(_UPDATED_QUANTITY))
 
 
@@ -39,9 +43,7 @@ def test_cart_item_update_button(global_settings: GlobalSettings, page: Page) ->
     line_item = cart_page.find_line_item(sku=_PRODUCT_ID)
     expect(line_item.root).to_be_visible()
     expect(line_item.add_to_cart_button.root).to_be_visible()
-    expect(line_item.add_to_cart_button.quantity_input).to_have_value(
-        str(_ORIGINAL_QUANTITY)
-    )
+    expect(line_item.add_to_cart_button.quantity_input).to_have_value(str(_ORIGINAL_QUANTITY))
 
     line_item.add_to_cart_button.quantity_input.fill(str(_UPDATED_QUANTITY))
     cart_page.click_outside()

--- a/tests/e2e/test_cart_merge.py
+++ b/tests/e2e/test_cart_merge.py
@@ -1,6 +1,9 @@
+import logging
+import time
 from typing import Any
 
 import pytest
+import requests
 from core.auth import AuthProvider
 from core.clients import GraphQLClient
 from core.global_settings import GlobalSettings
@@ -13,6 +16,8 @@ _PRODUCT_ID = "smartphone-samsung-galaxy-a57-5g"
 _QUANTITY = 3
 _USERNAME = "acme_store_employee_1@acme.com"
 
+_logger = logging.getLogger(__name__)
+
 
 def _cleanup_user_cart(
     global_settings: GlobalSettings,
@@ -21,7 +26,18 @@ def _cleanup_user_cart(
 ) -> None:
     user_ctx = Context.from_dataset(dataset, global_settings.store_id, _USERNAME)
     admin = AuthProvider(global_settings)
-    admin.sign_in(global_settings.admin_username, global_settings.admin_password)
+    # Demo platforms occasionally rate-limit / briefly lock /connect/token after the
+    # storefront UI sign-in this test performs. Retry on 400 so a transient lockout
+    # doesn't mark the test as broken when only the cleanup step is affected.
+    for attempt in range(3):
+        try:
+            admin.sign_in(global_settings.admin_username, global_settings.admin_password)
+            break
+        except requests.HTTPError as exc:
+            if attempt == 2 or (exc.response is not None and exc.response.status_code != 400):
+                _logger.warning("Skipping cart cleanup; admin sign-in failed: %s", exc)
+                return
+            time.sleep(2)
     with GraphQLClient(auth=admin, global_settings=global_settings) as client:
         cart_ops = CartOperations(client)
         cart = cart_ops.get_cart(
@@ -54,9 +70,7 @@ def test_cart_merge_stepper(
         sign_in_page.navigate()
 
         sign_in_page.email_input.fill(_USERNAME)
-        sign_in_page.password_input.fill(
-            global_settings.users_password.get_secret_value()
-        )
+        sign_in_page.password_input.fill(global_settings.users_password.get_secret_value())
         sign_in_page.sign_in_button.click()
 
         cart_page.navigate()
@@ -87,16 +101,12 @@ def test_cart_merge_button(
         sign_in_page.navigate()
 
         sign_in_page.email_input.fill(_USERNAME)
-        sign_in_page.password_input.fill(
-            global_settings.users_password.get_secret_value()
-        )
+        sign_in_page.password_input.fill(global_settings.users_password.get_secret_value())
         sign_in_page.sign_in_button.click()
 
         cart_page.navigate()
         line_item = cart_page.find_line_item(sku=_PRODUCT_ID)
         expect(line_item.root).to_be_visible()
-        expect(line_item.add_to_cart_button.quantity_input).to_have_value(
-            str(_QUANTITY)
-        )
+        expect(line_item.add_to_cart_button.quantity_input).to_have_value(str(_QUANTITY))
     finally:
         _cleanup_user_cart(global_settings, dataset, ctx)

--- a/tests/e2e/test_category_variations_update_cart.py
+++ b/tests/e2e/test_category_variations_update_cart.py
@@ -1,7 +1,7 @@
 import pytest
 from core.global_settings import GlobalSettings
 from page_objects.pages.category import CategoryPage
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Response, expect
 
 _CATEGORY_PATH = "smartphones"
 _PRODUCT_SKU = "smartphone-google-pixel-10-frost"
@@ -9,15 +9,16 @@ _VARIATION_1_SKU = "smartphone-google-pixel-10-indigo"
 _VARIATION_2_SKU = "smartphone-google-pixel-10-lemongrass"
 
 
+def _is_cart_mutation(response: Response) -> bool:
+    post = response.request.post_data
+    return bool(post and "/graphql" in response.url and "mutation" in post)
+
+
 @pytest.mark.e2e
 @pytest.mark.quantity_control("stepper")
 @pytest.mark.delete_cart_after
-def test_category_variation_update_cart_stepper(
-    global_settings: GlobalSettings, page: Page
-) -> None:
-    category_page = CategoryPage(
-        global_settings=global_settings, page=page, path=_CATEGORY_PATH
-    )
+def test_category_variation_update_cart_stepper(global_settings: GlobalSettings, page: Page) -> None:
+    category_page = CategoryPage(global_settings=global_settings, page=page, path=_CATEGORY_PATH)
     category_page.navigate()
 
     category_page.view_switcher.list_view_tab.click()
@@ -30,31 +31,33 @@ def test_category_variation_update_cart_stepper(
     variation_1 = product_card.find_variation_item(sku=_VARIATION_1_SKU)
     variation_2 = product_card.find_variation_item(sku=_VARIATION_2_SKU)
 
-    variation_1.quantity_stepper.increment_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_1.quantity_stepper.increment_button.click()
     expect(category_page.cart_quantity_label).to_have_text("1")
-    variation_1.quantity_stepper.increment_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_1.quantity_stepper.increment_button.click()
     expect(category_page.cart_quantity_label).to_have_text("2")
 
-    variation_2.quantity_stepper.increment_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_2.quantity_stepper.increment_button.click()
     expect(category_page.cart_quantity_label).to_have_text("3")
-    variation_2.quantity_stepper.increment_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_2.quantity_stepper.increment_button.click()
     expect(category_page.cart_quantity_label).to_have_text("4")
 
-    variation_1.quantity_stepper.decrement_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_1.quantity_stepper.decrement_button.click()
     expect(category_page.cart_quantity_label).to_have_text("3")
-    variation_2.quantity_stepper.decrement_button.click()
+    with page.expect_response(_is_cart_mutation):
+        variation_2.quantity_stepper.decrement_button.click()
     expect(category_page.cart_quantity_label).to_have_text("2")
 
 
 @pytest.mark.e2e
 @pytest.mark.quantity_control("button")
 @pytest.mark.delete_cart_after
-def test_category_variation_update_cart_button(
-    global_settings: GlobalSettings, page: Page
-) -> None:
-    category_page = CategoryPage(
-        global_settings=global_settings, page=page, path=_CATEGORY_PATH
-    )
+def test_category_variation_update_cart_button(global_settings: GlobalSettings, page: Page) -> None:
+    category_page = CategoryPage(global_settings=global_settings, page=page, path=_CATEGORY_PATH)
     category_page.navigate()
 
     category_page.view_switcher.list_view_tab.click()


### PR DESCRIPTION
…nt cleanup

Three flaky e2e tests were failing on slow demo backends:

- test_cart_item_update_stepper / test_category_variation_update_cart_stepper: the stepper increment/decrement click sends an async cart mutation; the badge update outran the default 5s assertion timeout. Wait for the mutation response via page.expect_response(_is_cart_mutation) before asserting, instead of bumping timeouts.

- test_cart_merge_stepper: cleanup performed a fresh admin sign-in per test, which intermittently hit a brief /connect/token rate-limit and marked the test as broken even when the body passed. Retry up to 3x with a 2s backoff on 400, then degrade to a logged warning so cleanup-only flakiness no longer fails the run.