### PR TITLE
fix(graphql): make test_contacts_search_by_name robust to fuzzy search

### DIFF
--- a/tests/graphql/test_contact_search.py
+++ b/tests/graphql/test_contact_search.py
@@ -19,8 +19,9 @@ def test_contacts_search_by_name(graphql_client: GraphQLClient, ctx: Context) ->
     )
 
     assert len(contacts) > 0
-    assert all(_CONTACT_FULL_NAME in c.full_name for c in contacts)
-    assert any(c.id == _CONTACT_ID for c in contacts)
+    target = next((c for c in contacts if c.id == _CONTACT_ID), None)
+    assert target is not None, f"Search did not return {_CONTACT_ID}"
+    assert _CONTACT_FULL_NAME in target.full_name
 
 
 @pytest.mark.graphql


### PR DESCRIPTION
The backend's contact search is token-based: searching for "ACME Employee A" returns all "ACME Employee *" contacts. The previous assertion `all(_CONTACT_FULL_NAME in c.full_name for c in contacts)` failed because results include "ACME Employee B", "C", … whose full_name doesn't contain the substring "ACME Employee A".

Verify the target contact specifically by ID, then assert its full_name matches — same intent, robust to fuzzy/token search semantics. This mirrors the pattern already used by test_contacts_search_by_email.