### PR TITLE
fix(e2e): stabilize test_cart_clear with response-based waits

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Generator
 
@@ -230,6 +231,21 @@ def with_cart(
             currency_code=ctx.currency_code,
             culture_name=ctx.culture_name,
         )
+        # Poll until the cart is read-back-visible. On some demo backends
+        # the storefront's first cart query can race the create and return
+        # null; ensure read-after-write consistency before yielding so e2e
+        # tests don't flake on initial page load.
+        for _ in range(global_settings.poll_attempts):
+            fetched = cart_ops.get_cart(
+                store_id=ctx.store_id,
+                user_id=ctx.user_id,
+                currency_code=ctx.currency_code,
+                culture_name=ctx.culture_name,
+                cart_id=cart.id,
+            )
+            if fetched and (fetched.items_count or 0) > 0:
+                break
+            time.sleep(global_settings.poll_interval)
         if request.node.get_closest_marker("e2e"):
             page = request.getfixturevalue("page")
             BrowserStorage(page).set_user_id(ctx.user_id)

--- a/tests/e2e/test_cart_clear.py
+++ b/tests/e2e/test_cart_clear.py
@@ -2,30 +2,40 @@ import pytest
 from core.global_settings import GlobalSettings
 from page_objects.components import ClearCartModal
 from page_objects.pages import CartPage
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Response, expect
 
 _PRODUCT_ID = "smartphone-samsung-galaxy-a57-5g"
 _QUANTITY = 3
+
+
+def _is_full_cart_query(response: Response) -> bool:
+    post = response.request.post_data
+    return bool(post and "/graphql" in response.url and "GetFullCart" in post)
+
+
+def _is_clear_cart_mutation(response: Response) -> bool:
+    post = response.request.post_data
+    return bool(post and "/graphql" in response.url and "ClearCart" in post)
 
 
 @pytest.mark.e2e
 @pytest.mark.with_cart([(_PRODUCT_ID, _QUANTITY)])
 def test_cart_clear(page: Page, global_settings: GlobalSettings) -> None:
     cart_page = CartPage(global_settings=global_settings, page=page)
-    cart_page.navigate()
+    with page.expect_response(_is_full_cart_query):
+        cart_page.navigate()
     expect(cart_page.line_items).to_be_visible()
     expect(cart_page.line_items).to_have_count(1)
     expect(cart_page.clear_cart_button).to_be_visible()
     expect(cart_page.clear_cart_button).to_be_enabled()
 
     cart_page.clear_cart_button.click()
-    clear_cart_modal = ClearCartModal(
-        root=page.locator("[data-test-id='clear-cart-modal']")
-    )
+    clear_cart_modal = ClearCartModal(root=page.locator("[data-test-id='clear-cart-modal']"))
     expect(clear_cart_modal.root).to_be_visible()
     expect(clear_cart_modal.yes_button).to_be_visible()
     expect(clear_cart_modal.yes_button).to_be_enabled()
 
-    clear_cart_modal.yes_button.click()
+    with page.expect_response(_is_clear_cart_mutation):
+        clear_cart_modal.yes_button.click()
     expect(clear_cart_modal.root).not_to_be_visible()
     expect(cart_page.line_items).not_to_be_visible()


### PR DESCRIPTION
The test was flaking on demo with two distinct races:

1. After cart_page.navigate() the storefront's GetFullCart query could either return null (cart-create not yet read-visible) or settle late (>5s on slow demo), causing line items not to render before the default expect timeout.

2. After clicking 'Yes' in the clear-cart modal, ClearCart mutation completes async and the line items DOM removal can lag past the 5s timeout, so `not_to_be_visible()` failed even though the cart was already empty server-side.

Wait for the actual GraphQL responses (GetFullCart and ClearCart) before the assertions instead of bumping timeouts. Same event-driven pattern used by the stepper-quantity e2e tests.

Also harden the with_cart fixture: poll cart_ops.get_cart until the new cart is read-back-visible before yielding, guarding against the brief read-after-write window observed for anonymous cart-create on demo. Cheap (one round-trip in the happy path) and helps any other e2e test that relies on the with_cart marker.