### PR TITLE
VCST-5041: Update auto-tests workflow

### DIFF
--- a/.github/workflows/auto-tests.yml
+++ b/.github/workflows/auto-tests.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   e2e-tests:
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
     with:
       installModules: 'false'
       installCustomModule: 'false'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
       PLAYWRIGHT_HEADLESS: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/graphql-tests.yml
+++ b/.github/workflows/graphql-tests.yml
@@ -28,7 +28,7 @@ jobs:
         browser: [chromium]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/refactored-tests.yml
+++ b/.github/workflows/refactored-tests.yml
@@ -34,7 +34,7 @@ jobs:
       # 1. Checkout & install modules
       # ──────────────────────────────────────────────
       - name: Checkout testing repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: VirtoCommerce/vc-testing-module
           ref: ${{ github.ref_name }}

--- a/.github/workflows/restapi-tests-docker.yml
+++ b/.github/workflows/restapi-tests-docker.yml
@@ -37,7 +37,7 @@ jobs:
       # 1. Checkout & install modules
       # ──────────────────────────────────────────────
       - name: Checkout testing repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: VirtoCommerce/vc-testing-module
           ref: ${{ github.ref_name }}

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1025.0",
+  "PlatformVersion": "3.1026.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1025.0",
+  "PlatformImageTag": "3.1026.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -155,7 +155,7 @@
         },
         {
           "Id": "VirtoCommerce.TaskManagement",
-          "Version": "3.1000.0"
+          "Version": "3.1001.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPersonalization",
@@ -243,7 +243,7 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Seo",


### PR DESCRIPTION
- update workflow version
- update node 20 actions
- update packages list 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/config-only changes, but they may affect CI stability due to upgraded reusable workflow/action versions and newer platform/module packages.
> 
> **Overview**
> Updates the CI test workflows to newer versions: `auto-tests.yml` now uses `VirtoCommerce/.github` reusable `pytest-tests.yml@v3.800.31`, and the `e2e`, `graphql`, `refactored`, and `restapi-tests-docker` workflows bump `actions/checkout` from `v4` to `v6`.
> 
> Refreshes `backend-packages.json` used by docker-based tests by bumping the platform from `3.1025.0` to `3.1026.0` (including `PlatformImageTag`) and updating module versions for `VirtoCommerce.TaskManagement` (`3.1000.0` → `3.1001.0`) and `VirtoCommerce.Xapi` (`3.1006.0` → `3.1007.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6c9f326868ed1704ce464bf3feb4087e7ea240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->