### PR TITLE
VCST-4576: Issue token based on e2e fixture

### DIFF
--- a/.claude/agents/qa-automation-expert.md
+++ b/.claude/agents/qa-automation-expert.md
@@ -173,7 +173,7 @@ Thread-safe token management with auto-refresh:
 ```python
 from core.auth import AuthProvider
 
-provider = AuthProvider(global_settings)
+provider = AuthProvider(global_settings.backend_base_url)
 provider.sign_in(username, global_settings.users_password)
 # provider.headers auto-refreshes expired tokens
 provider.sign_out()

--- a/.claude/skills/write-rest-api-test/SKILL.md
+++ b/.claude/skills/write-rest-api-test/SKILL.md
@@ -111,7 +111,7 @@ from core.global_settings import GlobalSettings
 
 @pytest.fixture(scope="session")
 def admin_auth(global_settings: GlobalSettings) -> AuthProvider:
-    provider = AuthProvider(global_settings)
+    provider = AuthProvider(global_settings.backend_base_url)
     provider.sign_in(global_settings.admin_username, global_settings.admin_password)
     return provider
 

--- a/core/auth/provider.py
+++ b/core/auth/provider.py
@@ -11,8 +11,11 @@ from core.global_settings import GlobalSettings
 class AuthProvider:
     _AUTH_TOKEN_PATH: Final = "/connect/token"
 
-    def __init__(self, global_settings: GlobalSettings) -> None:
+    def __init__(
+        self, global_settings: GlobalSettings, base_url: str | None = None
+    ) -> None:
         self._global_settings = global_settings
+        self._base_url = base_url or global_settings.backend_base_url
         self._token_info: TokenInfo | None = None
         self._lock = threading.RLock()
 
@@ -52,7 +55,7 @@ class AuthProvider:
 
         s = self._global_settings
         response = requests.post(
-            url=f"{s.backend_base_url}{self._AUTH_TOKEN_PATH}",
+            url=f"{self._base_url}{self._AUTH_TOKEN_PATH}",
             data={"grant_type": "refresh_token", "refresh_token": refresh_token},
             timeout=s.requests_timeout,
             verify=s.verify_ssl,
@@ -77,7 +80,7 @@ class AuthProvider:
             "password": password.get_secret_value(),
         }
         response = requests.post(
-            url=f"{s.backend_base_url}{self._AUTH_TOKEN_PATH}",
+            url=f"{self._base_url}{self._AUTH_TOKEN_PATH}",
             data=payload,
             timeout=s.requests_timeout,
             verify=s.verify_ssl,

--- a/core/auth/provider.py
+++ b/core/auth/provider.py
@@ -5,17 +5,14 @@ import requests
 from pydantic import SecretStr
 
 from core.auth.token_info import TokenInfo
-from core.global_settings import GlobalSettings
+from core.global_settings import global_settings
 
 
 class AuthProvider:
     _AUTH_TOKEN_PATH: Final = "/connect/token"
 
-    def __init__(
-        self, global_settings: GlobalSettings, base_url: str | None = None
-    ) -> None:
-        self._global_settings = global_settings
-        self._base_url = base_url or global_settings.backend_base_url
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
         self._token_info: TokenInfo | None = None
         self._lock = threading.RLock()
 
@@ -57,12 +54,11 @@ class AuthProvider:
                 )
             refresh_token = self._token_info.refresh_token
 
-        s = self._global_settings
         response = requests.post(
             url=f"{self._base_url}{self._AUTH_TOKEN_PATH}",
             data={"grant_type": "refresh_token", "refresh_token": refresh_token},
-            timeout=s.requests_timeout,
-            verify=s.verify_ssl,
+            timeout=global_settings.requests_timeout,
+            verify=global_settings.verify_ssl,
         )
         try:
             response.raise_for_status()
@@ -75,19 +71,18 @@ class AuthProvider:
             self._token_info = TokenInfo.model_validate(response.json())
 
     def sign_in(self, username: str, password: SecretStr) -> None:
-        s = self._global_settings
         payload = {
             "grant_type": "password",
             "scope": "offline_access",
             "username": username,
-            "storeId": s.store_id,
+            "storeId": global_settings.store_id,
             "password": password.get_secret_value(),
         }
         response = requests.post(
             url=f"{self._base_url}{self._AUTH_TOKEN_PATH}",
             data=payload,
-            timeout=s.requests_timeout,
-            verify=s.verify_ssl,
+            timeout=global_settings.requests_timeout,
+            verify=global_settings.verify_ssl,
         )
         try:
             response.raise_for_status()

--- a/core/auth/provider.py
+++ b/core/auth/provider.py
@@ -20,6 +20,10 @@ class AuthProvider:
         self._lock = threading.RLock()
 
     @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
     def is_authenticated(self) -> bool:
         with self._lock:
             return self._token_info is not None and not self._token_info.is_expired

--- a/core/clients/graphql.py
+++ b/core/clients/graphql.py
@@ -19,7 +19,7 @@ class GraphQLClient:
         self, query: str, variables: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         response = self._session.post(
-            url=f"{self._global_settings.backend_base_url}{self._GRAPHQL_PATH}",
+            url=f"{self._auth.base_url}{self._GRAPHQL_PATH}",
             headers=self._auth.headers,
             json={"query": query, "variables": variables or {}},
             timeout=self._global_settings.requests_timeout,

--- a/dataset/dataset_manager.py
+++ b/dataset/dataset_manager.py
@@ -70,7 +70,7 @@ class DatasetManager:
         if not entries:
             return 0
 
-        auth = AuthProvider(self._global_settings)
+        auth = AuthProvider(self._global_settings.backend_base_url)
         auth.sign_in(
             username=self._global_settings.admin_username,
             password=self._global_settings.admin_password,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def global_settings() -> GlobalSettings:
 
 @pytest.fixture(scope="session")
 def auth(global_settings: GlobalSettings) -> AuthProvider:
-    return AuthProvider(global_settings)
+    return AuthProvider(global_settings.backend_base_url)
 
 
 @pytest.fixture(scope="session")
@@ -206,8 +206,12 @@ def with_user(
     request: pytest.FixtureRequest, global_settings: GlobalSettings
 ) -> Generator[AuthProvider, None, None]:
     is_e2e = request.node.get_closest_marker("e2e") is not None
-    base_url = global_settings.frontend_base_url if is_e2e else None
-    provider = AuthProvider(global_settings, base_url=base_url)
+    base_url = (
+        global_settings.frontend_base_url
+        if is_e2e
+        else global_settings.backend_base_url
+    )
+    provider = AuthProvider(base_url)
     marker = request.node.get_closest_marker("with_user")
     if marker:
         username: str = marker.args[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,13 +205,15 @@ def graphql_client(
 def with_user(
     request: pytest.FixtureRequest, global_settings: GlobalSettings
 ) -> Generator[AuthProvider, None, None]:
-    provider = AuthProvider(global_settings)
+    is_e2e = request.node.get_closest_marker("e2e") is not None
+    base_url = global_settings.frontend_base_url if is_e2e else None
+    provider = AuthProvider(global_settings, base_url=base_url)
     marker = request.node.get_closest_marker("with_user")
     if marker:
         username: str = marker.args[0]
         with allure.step(f"Sign in as {username}"):
             provider.sign_in(username, global_settings.users_password)
-            if request.node.get_closest_marker("e2e") and provider.token_info:
+            if is_e2e and provider.token_info:
                 page = request.getfixturevalue("page")
                 BrowserStorage(page).set_auth(provider.token_info)
     yield provider

--- a/tests/e2e/test_cart_merge.py
+++ b/tests/e2e/test_cart_merge.py
@@ -26,7 +26,7 @@ def _cleanup_user_cart(
     ctx: Context,
 ) -> None:
     user_ctx = Context.from_dataset(dataset, global_settings.store_id, _USERNAME)
-    admin = AuthProvider(global_settings)
+    admin = AuthProvider(global_settings.backend_base_url)
     # Demo platforms occasionally rate-limit / briefly lock /connect/token after the
     # storefront UI sign-in this test performs. Retry on 400 so a transient lockout
     # doesn't mark the test as broken when only the cleanup step is affected.

--- a/tests/graphql/test_contact_register.py
+++ b/tests/graphql/test_contact_register.py
@@ -21,7 +21,7 @@ _STATUS_APPROVED = "Approved"
 
 
 def _admin_client(global_settings: GlobalSettings) -> GraphQLClient:
-    admin = AuthProvider(global_settings)
+    admin = AuthProvider(global_settings.backend_base_url)
     admin.sign_in(global_settings.admin_username, global_settings.admin_password)
     return GraphQLClient(auth=admin, global_settings=global_settings)
 

--- a/tests/graphql/test_user_invite.py
+++ b/tests/graphql/test_user_invite.py
@@ -77,7 +77,7 @@ def test_user_invite(
             assert any(a.user_name == email for a in invited_contact.security_accounts)
     finally:
         with allure.step(f"Teardown: delete invited user '{email}' as admin"):
-            admin = AuthProvider(global_settings)
+            admin = AuthProvider(global_settings.backend_base_url)
             admin.sign_in(global_settings.admin_username, global_settings.admin_password)
             with GraphQLClient(auth=admin, global_settings=global_settings) as admin_client:
                 UserOperations(client=admin_client).delete_users(user_names=[email])

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -21,7 +21,7 @@ from core.global_settings import GlobalSettings
 @pytest.fixture(scope="session")
 def admin_auth(global_settings: GlobalSettings) -> Generator[AuthProvider, None, None]:
     """Session-scoped admin auth — signed in once, reused across all REST tests."""
-    provider = AuthProvider(global_settings)
+    provider = AuthProvider(global_settings.backend_base_url)
     provider.sign_in(global_settings.admin_username, global_settings.admin_password)
     yield provider
     provider.sign_out()

--- a/tests/restapi/platform/test_roles.py
+++ b/tests/restapi/platform/test_roles.py
@@ -125,7 +125,7 @@ def test_role_assign_to_user(
     user = make_user()
 
     with allure.step("Verify user signs in with starting credentials"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(user["password"]))
         assert provider.is_authenticated
         provider.sign_out()

--- a/tests/restapi/platform/test_user.py
+++ b/tests/restapi/platform/test_user.py
@@ -134,7 +134,7 @@ def test_user_login_logout(make_user, global_settings: GlobalSettings, rest_clie
     user = make_user()
 
     with allure.step("Login via /connect/token"):
-        login_auth = AuthProvider(global_settings)
+        login_auth = AuthProvider(global_settings.backend_base_url)
         login_auth.sign_in(user["user_name"], SecretStr(user["password"]))
         assert login_auth.is_authenticated
 

--- a/tests/restapi/platform/test_user_lock.py
+++ b/tests/restapi/platform/test_user_lock.py
@@ -39,7 +39,7 @@ def test_user_lock_unlock(make_user, user_ops: UserOperations, global_settings: 
         user_ops.unlock(full_user.id)
 
     with allure.step("Verify login works after unlock"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(user["password"]))
         assert provider.is_authenticated
         provider.sign_out()

--- a/tests/restapi/platform/test_user_password.py
+++ b/tests/restapi/platform/test_user_password.py
@@ -26,7 +26,7 @@ def test_user_password_reset_admin(make_user, user_ops: UserOperations, global_s
         assert result.get("succeeded") is True
 
     with allure.step("Verify new password works"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(new_password))
         assert provider.is_authenticated
         provider.sign_out()
@@ -46,7 +46,7 @@ def test_user_password_change(make_user, user_ops: UserOperations, global_settin
         assert result.get("succeeded") is True
 
     with allure.step("Verify new password works"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(new_password))
         assert provider.is_authenticated
         provider.sign_out()
@@ -104,7 +104,7 @@ def test_user_password_change_wrong_old(make_user, user_ops: UserOperations, glo
         assert result.get("succeeded") is False or result.get("errors")
 
     with allure.step("Verify original password still works"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(user["password"]))
         assert provider.is_authenticated
         provider.sign_out()
@@ -132,7 +132,7 @@ def test_user_password_reset_on_login(make_user, user_ops: UserOperations, globa
         assert response.status_code == 400
 
     with allure.step("Verify new password works"):
-        provider = AuthProvider(global_settings)
+        provider = AuthProvider(global_settings.backend_base_url)
         provider.sign_in(user["user_name"], SecretStr(new_password))
         assert provider.is_authenticated
         provider.sign_out()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared authentication plumbing (`AuthProvider`) and updates many call sites; misconfigured base URLs could break sign-in/token refresh and GraphQL calls across test suites, especially for E2E runs.
> 
> **Overview**
> Decouples `AuthProvider` from `GlobalSettings` by changing it to accept an explicit `base_url`, exposing it via `AuthProvider.base_url`, and using the `global_settings` singleton only for shared request options and `storeId`.
> 
> Updates GraphQL and test/fixture call sites to construct `AuthProvider` with `backend_base_url` by default, and adjusts the `with_user` fixture to switch to `frontend_base_url` for `@pytest.mark.e2e` so E2E can obtain tokens against the appropriate host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580fac1a0ae7e2dc89a1ee578320705c310c228c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->