### PR TITLE
test(e2e): mark wishlist tests as ignore

### DIFF
--- a/tests/e2e/test_wishlist_add_all_to_cart.py
+++ b/tests/e2e/test_wishlist_add_all_to_cart.py
@@ -25,8 +25,8 @@ def _is_cart_from_wishlist_mutation(response: Response) -> bool:
     return "mutation" in post and "cart" in post
 
 
-@pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.skip
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Add products to cart (E2E)")
 @allure.title("Add all wishlist products to cart from list details")

--- a/tests/e2e/test_wishlist_add_all_to_cart.py
+++ b/tests/e2e/test_wishlist_add_all_to_cart.py
@@ -25,6 +25,7 @@ def _is_cart_from_wishlist_mutation(response: Response) -> bool:
     return "mutation" in post and "cart" in post
 
 
+@pytest.mark.ignore
 @pytest.mark.e2e
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Add products to cart (E2E)")

--- a/tests/e2e/test_wishlist_add_product.py
+++ b/tests/e2e/test_wishlist_add_product.py
@@ -54,6 +54,7 @@ def _open_from_pdp(page: Page, global_settings: GlobalSettings) -> str:
     return _VARIATION_PRODUCT_SKU
 
 
+@pytest.mark.ignore
 @pytest.mark.e2e
 @pytest.mark.with_user(_USERNAME)
 @pytest.mark.parametrize(

--- a/tests/e2e/test_wishlist_add_product.py
+++ b/tests/e2e/test_wishlist_add_product.py
@@ -54,8 +54,8 @@ def _open_from_pdp(page: Page, global_settings: GlobalSettings) -> str:
     return _VARIATION_PRODUCT_SKU
 
 
-@pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.skip
 @pytest.mark.with_user(_USERNAME)
 @pytest.mark.parametrize(
     "open_add_to_list,source_label",

--- a/tests/e2e/test_wishlist_manage_lists.py
+++ b/tests/e2e/test_wishlist_manage_lists.py
@@ -26,8 +26,8 @@ def _is_wishlist_manage_mutation(response: Response) -> bool:
     return "mutation" in post and "wishlist" in post
 
 
-@pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.skip
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / List management (E2E)")
 @allure.title("Create, edit, and remove wishlists with Private, Any, and Organization scopes")

--- a/tests/e2e/test_wishlist_manage_lists.py
+++ b/tests/e2e/test_wishlist_manage_lists.py
@@ -26,6 +26,7 @@ def _is_wishlist_manage_mutation(response: Response) -> bool:
     return "mutation" in post and "wishlist" in post
 
 
+@pytest.mark.ignore
 @pytest.mark.e2e
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / List management (E2E)")

--- a/tests/e2e/test_wishlist_remove_product.py
+++ b/tests/e2e/test_wishlist_remove_product.py
@@ -25,8 +25,8 @@ def _is_wishlist_item_mutation(response: Response) -> bool:
     return "mutation" in post and "wishlist" in post
 
 
-@pytest.mark.ignore
 @pytest.mark.e2e
+@pytest.mark.skip
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Remove product (E2E)")
 @allure.title("Remove a product from a wishlist via the add-to-list modal")

--- a/tests/e2e/test_wishlist_remove_product.py
+++ b/tests/e2e/test_wishlist_remove_product.py
@@ -25,6 +25,7 @@ def _is_wishlist_item_mutation(response: Response) -> bool:
     return "mutation" in post and "wishlist" in post
 
 
+@pytest.mark.ignore
 @pytest.mark.e2e
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Remove product (E2E)")


### PR DESCRIPTION
Add @pytest.mark.ignore to all wishlist E2E tests to exclude them from runs, matching the existing convention in test_cart_clear.py.