### PR TITLE
test(graphql): cart validation errors with ruleSet — per-line + cart (VCST-5240)

### DIFF
--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,19 +1,15 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1026.0",
+  "PlatformVersion": "3.1037.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1026.0",
+  "PlatformImageTag": "3.1037.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
     "Name": "AzureBlob",
     "Container": "packages",
     "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-    "Modules": [
-      {
-        "BlobName": "VirtoCommerce.XCart_3.1011.0-pr-113-b17e.zip"
-      } 
-    ]
+    "Modules": []
     },
     {
       "Name": "GithubReleases",
@@ -21,32 +17,12 @@
         "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
       ],
       "Modules": [
-       {
+ {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"
         },
         {
-          "Id": "VirtoCommerce.ElasticAppSearch",
-          "Version": "3.816.0"
-        },
-        {
           "Id": "VirtoCommerce.XFrontend",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Search",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.OpenIdConnectModule",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Export",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.BulkActionsModule",
           "Version": "3.1000.0"
         },
         {
@@ -54,43 +30,11 @@
           "Version": "3.1000.0"
         },
         {
-          "Id": "VirtoCommerce.DynamicAssociationsModule",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.FileSystemAssets",
-          "Version": "3.1000.0"
-        },
-        {
           "Id": "VirtoCommerce.EnvironmentsCompare",
           "Version": "3.1000.0"
         },
         {
-          "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
-          "Version": "4.1000.0"
-        },
-        {
           "Id": "VirtoCommerce.Return",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.ApplicationInsights",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.AuthorizeNetPayment",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.AvalaraTax",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.AzureAD",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.GoogleSSO",
           "Version": "3.1000.0"
         },
         {
@@ -98,248 +42,312 @@
           "Version": "3.1000.0"
         },
         {
-          "Id": "VirtoCommerce.PushMessages",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.XRecommend",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Quote",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.CustomerExportImport",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Subscription",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCMS",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.CyberSourcePayment",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Tax",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.ImageTools",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.PriceExportImport",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackInStock",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.OpenSearch",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.News",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.TaskManagement",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogPersonalization",
-          "Version": "3.1001.0"
-        },
-        {
           "Id": "VirtoCommerce.OpenTelemetry",
           "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.MarketingExperienceApi",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.ShipStation",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.AzureSearch",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.AzureBlobAssets",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.ElasticSearch8",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Cart",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.WebHooks",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Assets",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.LuceneSearch",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.NativePaymentMethods",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Marketing",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Payment",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Datatrans",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.CustomerReviews",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1007.0"
-        },
-        {
-          "Id": "VirtoCommerce.Seo",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Core",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.FileExperienceApi",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Store",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogPublishing",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1020.0"
-        },
-        {
-          "Id": "VirtoCommerce.EventBus",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Shipping",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.OrderManagement",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pages",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Customer",
-          "Version": "3.1007.0"
-        },
-        {
-          "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.SqlQueries",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.Sanity",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.BuilderIO",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.PageBuilderModule",
-          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.Contentful",
           "Version": "3.1001.0"
         },
         {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1007.0"
-        },
-        {
           "Id": "VirtoCommerce.XOrder",
           "Version": "3.1004.0"
         },
         {
-          "Id": "VirtoCommerce.ProductSnapshot",
-          "Version": "3.1000.0"
+          "Id": "VirtoCommerce.TaskManagement",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1008.0"
+        },
+        {
+          "Id": "VirtoCommerce.SystemOperations",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProfileExperienceApiModule",
+          "Version": "3.1007.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pricing",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Inventory",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Shipping",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Payment",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Notifications",
+          "Version": "3.1008.0"
+        },
+        {
+          "Id": "VirtoCommerce.Tax",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Marketing",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Subscription",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1028.0"
+        },
+        {
+          "Id": "VirtoCommerce.Store",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureSearch",
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Content",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Sitemaps",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Export",
           "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.ImageTools",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.LuceneSearch",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.CustomerReviews",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogPersonalization",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.AvalaraTax",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogPublishing",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.BulkActionsModule",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Quote",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.PriceExportImport",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.CustomerExportImport",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.EventBus",
+          "Version": "3.1009.0"
+        },
+        {
+          "Id": "VirtoCommerce.WebHooks",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
+          "Version": "4.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.DynamicAssociationsModule",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.NativePaymentMethods",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.ShipStation",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Contracts",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.AuthorizeNetPayment",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.ElasticAppSearch",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.MarketingExperienceApi",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureAD",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileExperienceApi",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.ElasticSearch8",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.WhiteLabeling",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.BuilderIO",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCatalog",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCMS",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.XRecommend",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Skyflow",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1010.0"
+        },
+        {
+          "Id": "VirtoCommerce.GoogleSSO",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.OpenIdConnectModule",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Search",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pages",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.OrderManagement",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Sanity",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Datatrans",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProductSnapshot",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackInStock",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.OpenSearch",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.SqlQueries",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.CyberSourcePayment",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Assets",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.ApplicationInsights",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureBlobAssets",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.Core",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Customer",
+          "Version": "3.1009.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileSystemAssets",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.PageBuilderModule",
+          "Version": "3.1011.0"
+        },
+        {
+          "Id": "VirtoCommerce.Seo",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.PushMessages",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.News",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Cart",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackupRestore",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "Version": "3.1019.0"
         }
        ]
     }

--- a/gql/fragments/line_item.graphql
+++ b/gql/fragments/line_item.graphql
@@ -20,4 +20,15 @@ fragment LineItemFragment on LineItemType {
     ...MoneyFragment
   }
   selectedForCheckout
+  isValid
+  validationErrors {
+    errorCode
+    errorMessage
+    errorParameters {
+      key
+      value
+    }
+    objectType
+    objectId
+  }
 }

--- a/gql/operations/cart_operations.py
+++ b/gql/operations/cart_operations.py
@@ -51,10 +51,10 @@ class CartOperations(BaseOperations):
         """Read cart-level validationErrors for an explicit ruleSet alongside the
         per-line validation fields, returning the raw ``cart`` payload.
 
-        The shared ``CartFragment`` always reads the default ``validationErrors``
-        (no ``ruleSet`` argument), so ruleSet-scoped reads need their own query.
-        The result is returned as a plain dict because callers assert on the
-        per-ruleSet response shape directly.
+        Returns a raw dict (not the ``Cart`` model): the ruleSet-scoped
+        ``validationErrors(ruleSet:)`` selection has no representation on the
+        ``Cart`` model, and callers assert on the per-ruleSet response shape
+        directly.
         """
         # fmt: off
         query = gql("""
@@ -62,7 +62,7 @@ class CartOperations(BaseOperations):
               cart(storeId: $storeId, userId: $userId, currencyCode: $currencyCode, cultureName: $cultureName, cartId: $cartId) {
                 itemsCount
                 validationErrors(ruleSet: $ruleSet) { errorCode objectType objectId errorMessage }
-                items { id sku productId quantity isValid validationErrors { errorCode objectType errorMessage } }
+                items { id sku productId quantity isValid validationErrors { errorCode objectType objectId errorMessage } }
               }
             }
         """)
@@ -95,7 +95,9 @@ class CartOperations(BaseOperations):
 
         Used to prove within-request ruleSet cache isolation: resolving one
         ruleSet must not leak its errors into (or poison) the other in the same
-        response. Returns the raw ``cart`` payload.
+        response. Returns a raw dict (not the ``Cart`` model): the aliased,
+        ruleSet-scoped ``validationErrors`` selections have no representation on
+        the ``Cart`` model.
         """
         # fmt: off
         query = gql("""
@@ -137,14 +139,15 @@ class CartOperations(BaseOperations):
         ``validationErrors`` re-validates the aggregate and would refill the
         per-line store, masking the bug. Omitting it ensures the per-line
         ``isValid`` / ``validationErrors`` are read straight from the saved
-        line. Returns the raw ``cart`` payload.
+        line. Returns a raw dict (not the ``Cart`` model) so the probe selects
+        only per-line fields and never triggers aggregate re-validation.
         """
         # fmt: off
         query = gql("""
             query GetCartLineValidation($storeId: String!, $userId: String!, $currencyCode: String!, $cultureName: String!, $cartId: String) {
               cart(storeId: $storeId, userId: $userId, currencyCode: $currencyCode, cultureName: $cultureName, cartId: $cartId) {
                 itemsCount
-                items { id sku productId quantity isValid validationErrors { errorCode objectType errorMessage } }
+                items { id sku productId quantity isValid validationErrors { errorCode objectType objectId errorMessage } }
               }
             }
         """)

--- a/gql/operations/cart_operations.py
+++ b/gql/operations/cart_operations.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from gql.operations.base_operations import BaseOperations, gql
 from gql.types.cart import Cart
 from gql.types.cart_item_input import CartItemInput
@@ -36,6 +38,128 @@ class CartOperations(BaseOperations):
         )
         data = result["data"]["cart"]
         return Cart.model_validate(data) if data else None
+
+    def get_cart_validation(
+        self,
+        store_id: str,
+        user_id: str,
+        currency_code: str,
+        culture_name: str,
+        rule_set: str,
+        cart_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Read cart-level validationErrors for an explicit ruleSet alongside the
+        per-line validation fields, returning the raw ``cart`` payload.
+
+        The shared ``CartFragment`` always reads the default ``validationErrors``
+        (no ``ruleSet`` argument), so ruleSet-scoped reads need their own query.
+        The result is returned as a plain dict because callers assert on the
+        per-ruleSet response shape directly.
+        """
+        # fmt: off
+        query = gql("""
+            query GetCartValidation($storeId: String!, $userId: String!, $currencyCode: String!, $cultureName: String!, $ruleSet: String, $cartId: String) {
+              cart(storeId: $storeId, userId: $userId, currencyCode: $currencyCode, cultureName: $cultureName, cartId: $cartId) {
+                itemsCount
+                validationErrors(ruleSet: $ruleSet) { errorCode objectType objectId errorMessage }
+                items { id sku productId quantity isValid validationErrors { errorCode objectType errorMessage } }
+              }
+            }
+        """)
+        # fmt: on
+        result = self._client.execute(
+            query,
+            variables={
+                "storeId": store_id,
+                "userId": user_id,
+                "currencyCode": currency_code,
+                "cultureName": culture_name,
+                "ruleSet": rule_set,
+                "cartId": cart_id,
+            },
+        )
+        return result["data"]["cart"]
+
+    def get_cart_validation_aliased(
+        self,
+        store_id: str,
+        user_id: str,
+        currency_code: str,
+        culture_name: str,
+        rule_set_a: str,
+        rule_set_b: str,
+        cart_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Read two ruleSet-scoped cart-level validationErrors within a SINGLE
+        request via GraphQL aliases (``errorsA`` / ``errorsB``).
+
+        Used to prove within-request ruleSet cache isolation: resolving one
+        ruleSet must not leak its errors into (or poison) the other in the same
+        response. Returns the raw ``cart`` payload.
+        """
+        # fmt: off
+        query = gql("""
+            query GetCartValidationAliased($storeId: String!, $userId: String!, $currencyCode: String!, $cultureName: String!, $ruleSetA: String, $ruleSetB: String, $cartId: String) {
+              cart(storeId: $storeId, userId: $userId, currencyCode: $currencyCode, cultureName: $cultureName, cartId: $cartId) {
+                itemsCount
+                errorsA: validationErrors(ruleSet: $ruleSetA) { errorCode objectType objectId errorMessage }
+                errorsB: validationErrors(ruleSet: $ruleSetB) { errorCode objectType objectId errorMessage }
+              }
+            }
+        """)
+        # fmt: on
+        result = self._client.execute(
+            query,
+            variables={
+                "storeId": store_id,
+                "userId": user_id,
+                "currencyCode": currency_code,
+                "cultureName": culture_name,
+                "ruleSetA": rule_set_a,
+                "ruleSetB": rule_set_b,
+                "cartId": cart_id,
+            },
+        )
+        return result["data"]["cart"]
+
+    def get_cart_line_validation(
+        self,
+        store_id: str,
+        user_id: str,
+        currency_code: str,
+        culture_name: str,
+        cart_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Read ONLY the per-line validation fields — no cart-level
+        ``validationErrors`` selection.
+
+        This is the decisive VCST-5234 probe: querying cart-level
+        ``validationErrors`` re-validates the aggregate and would refill the
+        per-line store, masking the bug. Omitting it ensures the per-line
+        ``isValid`` / ``validationErrors`` are read straight from the saved
+        line. Returns the raw ``cart`` payload.
+        """
+        # fmt: off
+        query = gql("""
+            query GetCartLineValidation($storeId: String!, $userId: String!, $currencyCode: String!, $cultureName: String!, $cartId: String) {
+              cart(storeId: $storeId, userId: $userId, currencyCode: $currencyCode, cultureName: $cultureName, cartId: $cartId) {
+                itemsCount
+                items { id sku productId quantity isValid validationErrors { errorCode objectType errorMessage } }
+              }
+            }
+        """)
+        # fmt: on
+        result = self._client.execute(
+            query,
+            variables={
+                "storeId": store_id,
+                "userId": user_id,
+                "currencyCode": currency_code,
+                "cultureName": culture_name,
+                "cartId": cart_id,
+            },
+        )
+        return result["data"]["cart"]
 
     def add_items_to_cart(
         self,

--- a/gql/types/line_item.py
+++ b/gql/types/line_item.py
@@ -1,5 +1,6 @@
 from gql.types.base import GqlModel
 from gql.types.money import Money
+from gql.types.validation_error import ValidationError
 
 
 class LineItem(GqlModel):
@@ -14,3 +15,5 @@ class LineItem(GqlModel):
     extended_price: Money | None = None
     discount_amount: Money | None = None
     selected_for_checkout: bool = True
+    is_valid: bool | None = None
+    validation_errors: list[ValidationError] = []

--- a/tests/graphql/test_cart_validation.py
+++ b/tests/graphql/test_cart_validation.py
@@ -90,7 +90,7 @@ def _seed_over_stock_line(cart_ops: CartOperations, ctx: Context) -> None:
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Per-line validationErrors survive an over-stock quantity change")
+@allure.title("Over-stock line should stay invalid with a per-line quantity error")
 def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLClient, ctx: Context) -> None:
     """VCST-5234 core guard: an over-stock line reports isValid=false + a
     per-line quantity error. Read per-line only (no cart-level validationErrors
@@ -121,7 +121,7 @@ def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLC
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Per-line validationErrors persist after a subsequent cart change")
+@allure.title("Per-line errors should persist after a subsequent cart change")
 def test_line_item_validation_persists_after_subsequent_change(graphql_client: GraphQLClient, ctx: Context) -> None:
     """The literal VCST-5234 symptom: per-line errors must NOT disappear after a
     later cart change. Over-stock a line, then add an unrelated valid line (a
@@ -156,7 +156,7 @@ def test_line_item_validation_persists_after_subsequent_change(graphql_client: G
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Per-line validity is isolated between lines")
+@allure.title("Valid sibling line should stay valid next to an over-stock line")
 def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClient, ctx: Context) -> None:
     """An over-stock line must not contaminate a sibling valid line: the
     over-stock line is invalid while the in-stock line stays valid."""
@@ -200,7 +200,7 @@ def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClien
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Cart-level validationErrors are scoped per ruleSet")
+@allure.title("Cart should expose validationErrors scoped per ruleSet")
 def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Context) -> None:
     """The item over-stock error belongs to the items scope: it surfaces under
     ruleSet ``*`` (union) and ``items``, but not under ``default``/``shipments``,
@@ -239,7 +239,7 @@ def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Con
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("ruleSet cache is isolated within a single request")
+@allure.title("ruleSet cache should stay isolated within a single request")
 def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQLClient, ctx: Context) -> None:
     """Two ruleSet-scoped validationErrors selections in one request (aliases)
     must not leak into or poison each other (VCST-4952 / PR #110)."""
@@ -276,7 +276,7 @@ def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQ
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("ruleSet cache is isolated across separate requests")
+@allure.title("ruleSet cache should stay isolated across separate requests")
 def test_cart_validation_ruleset_isolation_across_requests(graphql_client: GraphQLClient, ctx: Context) -> None:
     """Querying one ruleSet must not leak into / poison a subsequent request's
     ruleSet (each get_cart_validation call is a separate POST)."""
@@ -306,7 +306,7 @@ def test_cart_validation_ruleset_isolation_across_requests(graphql_client: Graph
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Validation errors clear after the cart is corrected")
+@allure.title("Validation errors should clear after the cart is corrected")
 def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, ctx: Context) -> None:
     """After correcting the quantity back within stock, both cart-level and
     per-line validation errors must clear (no stale errors)."""
@@ -342,7 +342,7 @@ def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, 
 @pytest.mark.graphql
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
-@allure.title("Validation errors clear after the over-stock line is removed")
+@allure.title("Validation errors should clear after the over-stock line is removed")
 def test_cart_validation_clears_after_line_removal(graphql_client: GraphQLClient, ctx: Context) -> None:
     """Complement to correction-by-quantity: an over-stock line reports
     ``isValid: false`` + per-line errors, then REMOVING that line clears the

--- a/tests/graphql/test_cart_validation.py
+++ b/tests/graphql/test_cart_validation.py
@@ -44,6 +44,31 @@ def _has_qty_error(errors: list[dict]) -> bool:
     return bool(_error_codes(errors) & _QTY_ERROR_CODES)
 
 
+def _assert_scoped_to_line(line: dict) -> None:
+    """Defensively confirm the per-line validation errors are scoped to the
+    LineItem (not the cart). The backend may omit objectType/objectId, so only
+    assert linkage when at least one is populated: an error whose objectType
+    names a line item OR whose objectId equals the line's own id.
+    """
+    errors = line["validationErrors"]
+    has_object_type = any(e.get("objectType") for e in errors)
+    has_object_id = any(e.get("objectId") for e in errors)
+    if not (has_object_type or has_object_id):
+        # Make the skipped check visible so a green run does not read as if
+        # linkage was asserted when the backend returned no scoping metadata.
+        with allure.step("scoping metadata absent (no objectType/objectId) — line linkage not asserted"):
+            pass
+        return
+    linked = any(
+        ("lineitem" in (e.get("objectType") or "").lower()) or (e.get("objectId") == line["id"]) for e in errors
+    )
+    assert linked, (
+        "expected a per-line validation error scoped to the LineItem "
+        f"(objectType ~ LineItem or objectId == {line['id']!r}), got "
+        f"{[(e.get('objectType'), e.get('objectId')) for e in errors]}"
+    )
+
+
 def _seed_over_stock_line(cart_ops: CartOperations, ctx: Context) -> None:
     """Add a valid line, then push it over stock via an update."""
     cart_ops.add_items_to_cart(
@@ -90,6 +115,7 @@ def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLC
         assert _has_qty_error(
             line["validationErrors"]
         ), f"expected a quantity error, got {_error_codes(line['validationErrors'])}"
+        _assert_scoped_to_line(line)
 
 
 @pytest.mark.graphql
@@ -124,6 +150,7 @@ def test_line_item_validation_persists_after_subsequent_change(graphql_client: G
         line = _find_line(cart["items"], _PRODUCT_ID)
         assert line is not None and line["isValid"] is False
         assert _has_qty_error(line["validationErrors"])
+        _assert_scoped_to_line(line)
 
 
 @pytest.mark.graphql
@@ -165,6 +192,7 @@ def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClien
         sibling = _find_line(cart["items"], _SIBLING_PRODUCT_ID)
         assert over is not None and over["isValid"] is False
         assert _has_qty_error(over["validationErrors"])
+        _assert_scoped_to_line(over)
         assert sibling is not None and sibling["isValid"] is True
         assert sibling["validationErrors"] == []
 
@@ -309,3 +337,50 @@ def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, 
         assert line is not None
         assert line["isValid"] is True
         assert line["validationErrors"] == []
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Validation errors clear after the over-stock line is removed")
+def test_cart_validation_clears_after_line_removal(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """Complement to correction-by-quantity: an over-stock line reports
+    ``isValid: false`` + per-line errors, then REMOVING that line clears the
+    cart-level and per-line validation errors (the line is simply gone)."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    with allure.step("Verify the over-stock line is invalid with a per-line error"):
+        cart = cart_ops.get_cart_line_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+        )
+        line = _find_line(cart["items"], _PRODUCT_ID)
+        assert line is not None and line["isValid"] is False
+        assert _has_qty_error(line["validationErrors"])
+        _assert_scoped_to_line(line)
+        line_item_id = line["id"]
+
+    with allure.step("Remove the over-stock line from the cart"):
+        cart_ops.remove_cart_item(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            line_item_id=line_item_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+        )
+
+    with allure.step("Verify cart-level and per-line errors for that line are gone"):
+        cart = cart_ops.get_cart_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set="*",
+        )
+        assert not _has_qty_error(cart["validationErrors"])
+        assert _find_line(cart["items"], _PRODUCT_ID) is None

--- a/tests/graphql/test_cart_validation.py
+++ b/tests/graphql/test_cart_validation.py
@@ -70,6 +70,7 @@ def _seed_over_stock_line(cart_ops: CartOperations, ctx: Context) -> None:
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Over-stock line should stay invalid with a per-line quantity error")
@@ -99,6 +100,7 @@ def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLC
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Per-line errors should persist after a subsequent cart change")
@@ -132,6 +134,7 @@ def test_line_item_validation_persists_after_subsequent_change(graphql_client: G
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Valid sibling line should stay valid next to an over-stock line")
@@ -176,6 +179,7 @@ def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClien
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Cart should expose validationErrors scoped per ruleSet")
@@ -212,6 +216,7 @@ def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Con
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("ruleSet cache should stay isolated within a single request")
@@ -248,6 +253,7 @@ def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQ
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("ruleSet cache should stay isolated across separate requests")
@@ -277,6 +283,7 @@ def test_cart_validation_ruleset_isolation_across_requests(graphql_client: Graph
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Validation errors should clear after the cart is corrected")
@@ -312,6 +319,7 @@ def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, 
 
 
 @pytest.mark.graphql
+@pytest.mark.optional
 @pytest.mark.delete_cart_after
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Validation errors should clear after the over-stock line is removed")

--- a/tests/graphql/test_cart_validation.py
+++ b/tests/graphql/test_cart_validation.py
@@ -1,0 +1,311 @@
+"""Cart validation errors with ruleSet — per-line and cart-level (VCST-5240).
+
+Regression coverage for VCST-5234: after a cart change, an over-stock line must
+keep reporting ``isValid: false`` + per-line ``validationErrors`` (these used to
+vanish — the line read back valid-when-invalid). Also guards ruleSet scoping and
+within-/cross-request ruleSet cache isolation introduced by XCart PR #110.
+
+Repro shape: add a valid line (qty 1), then push it over stock via
+``updateCartQuantity``. The over-stock quantity sits above the product's seeded
+stock but below the platform's 999_999 per-line cap, so the inventory rule fires
+(``PRODUCT_QTY_CHANGED`` / LineItem scope) rather than the line-limit rule.
+Carts are anonymous (random ``ctx.user_id``), matching the other cart suites.
+"""
+
+import allure
+import pytest
+from core.clients import GraphQLClient
+from gql.operations import CartOperations
+from gql.types import CartItemInput
+from tests.context import Context
+
+# In-stock, inventory-tracked products in the seeded ACME catalog.
+_PRODUCT_ID = "smartphone-apple-iphone-17-256gb-black"
+_SIBLING_PRODUCT_ID = "smartphone-apple-iphone-17-256gb-sage"
+_VALID_QTY = 1
+_SIBLING_QTY = 2
+# Above the seeded stock (~137k) yet below the 999_999 per-line cap, so the
+# over-stock inventory rule fires instead of LINE_ITEM_LIMIT.
+_OVER_STOCK_QTY = 500_000
+
+# Per-line / item over-stock surfaces under these codes (LineItem scope).
+_QTY_ERROR_CODES = {"PRODUCT_QTY_CHANGED", "PRODUCT_QTY_INSUFFICIENT"}
+
+
+def _find_line(items: list[dict], product_id: str) -> dict | None:
+    return next((i for i in items if i["productId"] == product_id), None)
+
+
+def _error_codes(errors: list[dict]) -> set[str]:
+    return {e["errorCode"] for e in errors}
+
+
+def _has_qty_error(errors: list[dict]) -> bool:
+    return bool(_error_codes(errors) & _QTY_ERROR_CODES)
+
+
+def _seed_over_stock_line(cart_ops: CartOperations, ctx: Context) -> None:
+    """Add a valid line, then push it over stock via an update."""
+    cart_ops.add_items_to_cart(
+        store_id=ctx.store_id,
+        user_id=ctx.user_id,
+        currency_code=ctx.currency_code,
+        culture_name=ctx.culture_name,
+        items=[CartItemInput(product_id=_PRODUCT_ID, quantity=_VALID_QTY)],
+    )
+    cart_ops.update_cart_quantity(
+        store_id=ctx.store_id,
+        user_id=ctx.user_id,
+        currency_code=ctx.currency_code,
+        culture_name=ctx.culture_name,
+        items=[CartItemInput(product_id=_PRODUCT_ID, quantity=_OVER_STOCK_QTY)],
+    )
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Per-line validationErrors survive an over-stock quantity change")
+def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """VCST-5234 core guard: an over-stock line reports isValid=false + a
+    per-line quantity error. Read per-line only (no cart-level validationErrors
+    field) so nothing re-validates the aggregate — the decisive probe."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step(f"Add {_PRODUCT_ID}×{_VALID_QTY}, then update to {_OVER_STOCK_QTY}"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    with allure.step("Read per-line validation only (no cart-level re-validation)"):
+        cart = cart_ops.get_cart_line_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+        )
+
+    with allure.step("Verify the over-stock line is invalid with a quantity error"):
+        line = _find_line(cart["items"], _PRODUCT_ID)
+        assert line is not None, "over-stock line was not retained in the cart"
+        assert line["isValid"] is False
+        assert _has_qty_error(
+            line["validationErrors"]
+        ), f"expected a quantity error, got {_error_codes(line['validationErrors'])}"
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Per-line validationErrors persist after a subsequent cart change")
+def test_line_item_validation_persists_after_subsequent_change(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """The literal VCST-5234 symptom: per-line errors must NOT disappear after a
+    later cart change. Over-stock a line, then add an unrelated valid line (a
+    save), and confirm the over-stock line is still invalid."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    with allure.step(f"Add a valid sibling line {_SIBLING_PRODUCT_ID}×{_SIBLING_QTY}"):
+        cart_ops.add_items_to_cart(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            items=[CartItemInput(product_id=_SIBLING_PRODUCT_ID, quantity=_SIBLING_QTY)],
+        )
+
+    with allure.step("Verify the over-stock line is STILL invalid after the change"):
+        cart = cart_ops.get_cart_line_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+        )
+        line = _find_line(cart["items"], _PRODUCT_ID)
+        assert line is not None and line["isValid"] is False
+        assert _has_qty_error(line["validationErrors"])
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Per-line validity is isolated between lines")
+def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """An over-stock line must not contaminate a sibling valid line: the
+    over-stock line is invalid while the in-stock line stays valid."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Add two valid lines, then push one over stock"):
+        cart_ops.add_items_to_cart(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            items=[
+                CartItemInput(product_id=_PRODUCT_ID, quantity=_VALID_QTY),
+                CartItemInput(product_id=_SIBLING_PRODUCT_ID, quantity=_SIBLING_QTY),
+            ],
+        )
+        cart_ops.update_cart_quantity(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            items=[CartItemInput(product_id=_PRODUCT_ID, quantity=_OVER_STOCK_QTY)],
+        )
+
+    with allure.step("Verify over-stock line invalid, sibling line valid"):
+        cart = cart_ops.get_cart_line_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+        )
+        over = _find_line(cart["items"], _PRODUCT_ID)
+        sibling = _find_line(cart["items"], _SIBLING_PRODUCT_ID)
+        assert over is not None and over["isValid"] is False
+        assert _has_qty_error(over["validationErrors"])
+        assert sibling is not None and sibling["isValid"] is True
+        assert sibling["validationErrors"] == []
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Cart-level validationErrors are scoped per ruleSet")
+def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """The item over-stock error belongs to the items scope: it surfaces under
+    ruleSet ``*`` (union) and ``items``, but not under ``default``/``shipments``,
+    and an unknown ruleSet returns nothing. The per-line signal stays invalid
+    regardless of which cart-level ruleSet is queried."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    def read(rule_set: str) -> dict:
+        return cart_ops.get_cart_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set=rule_set,
+        )
+
+    with allure.step("ruleSet '*' and 'items' surface the over-stock error"):
+        for rule_set in ("*", "items"):
+            cart = read(rule_set)
+            assert _has_qty_error(cart["validationErrors"]), f"ruleSet {rule_set!r} should contain the over-stock error"
+
+    with allure.step("ruleSet 'default', 'shipments', 'foo' do NOT carry item-qty errors"):
+        for rule_set in ("default", "shipments", "foo"):
+            cart = read(rule_set)
+            assert not _has_qty_error(
+                cart["validationErrors"]
+            ), f"ruleSet {rule_set!r} must not contain the item-qty error"
+            # per-line validity is independent of the cart-level ruleSet queried
+            line = _find_line(cart["items"], _PRODUCT_ID)
+            assert line is not None and line["isValid"] is False
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("ruleSet cache is isolated within a single request")
+def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """Two ruleSet-scoped validationErrors selections in one request (aliases)
+    must not leak into or poison each other (VCST-4952 / PR #110)."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    with allure.step("'*' then 'shipments' in one request: only '*' carries the error"):
+        cart = cart_ops.get_cart_validation_aliased(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set_a="*",
+            rule_set_b="shipments",
+        )
+        assert _has_qty_error(cart["errorsA"])
+        assert not _has_qty_error(cart["errorsB"])
+
+    with allure.step("unknown 'foo' then '*' in one request: 'foo' must not poison '*'"):
+        cart = cart_ops.get_cart_validation_aliased(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set_a="foo",
+            rule_set_b="*",
+        )
+        assert cart["errorsA"] == []
+        assert _has_qty_error(cart["errorsB"])
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("ruleSet cache is isolated across separate requests")
+def test_cart_validation_ruleset_isolation_across_requests(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """Querying one ruleSet must not leak into / poison a subsequent request's
+    ruleSet (each get_cart_validation call is a separate POST)."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    def read(rule_set: str) -> dict:
+        return cart_ops.get_cart_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set=rule_set,
+        )
+
+    with allure.step("'*' (req 1) carries the error; 'shipments' (req 2) does not"):
+        assert _has_qty_error(read("*")["validationErrors"])
+        assert not _has_qty_error(read("shipments")["validationErrors"])
+
+    with allure.step("unknown 'foo' (req 1) does not poison '*' (req 2)"):
+        assert not _has_qty_error(read("foo")["validationErrors"])
+        assert _has_qty_error(read("*")["validationErrors"])
+
+
+@pytest.mark.graphql
+@pytest.mark.delete_cart_after
+@allure.feature("Cart / Validation (GraphQL)")
+@allure.title("Validation errors clear after the cart is corrected")
+def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, ctx: Context) -> None:
+    """After correcting the quantity back within stock, both cart-level and
+    per-line validation errors must clear (no stale errors)."""
+    cart_ops = CartOperations(client=graphql_client)
+
+    with allure.step("Create an over-stock line"):
+        _seed_over_stock_line(cart_ops, ctx)
+
+    with allure.step(f"Correct the quantity back to {_VALID_QTY}"):
+        cart_ops.update_cart_quantity(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            items=[CartItemInput(product_id=_PRODUCT_ID, quantity=_VALID_QTY)],
+        )
+
+    with allure.step("Verify cart-level and per-line errors are cleared"):
+        cart = cart_ops.get_cart_validation(
+            store_id=ctx.store_id,
+            user_id=ctx.user_id,
+            currency_code=ctx.currency_code,
+            culture_name=ctx.culture_name,
+            rule_set="*",
+        )
+        assert not _has_qty_error(cart["validationErrors"])
+        line = _find_line(cart["items"], _PRODUCT_ID)
+        assert line is not None
+        assert line["isValid"] is True
+        assert line["validationErrors"] == []

--- a/tests/graphql/test_cart_validation.py
+++ b/tests/graphql/test_cart_validation.py
@@ -1,17 +1,3 @@
-"""Cart validation errors with ruleSet — per-line and cart-level (VCST-5240).
-
-Regression coverage for VCST-5234: after a cart change, an over-stock line must
-keep reporting ``isValid: false`` + per-line ``validationErrors`` (these used to
-vanish — the line read back valid-when-invalid). Also guards ruleSet scoping and
-within-/cross-request ruleSet cache isolation introduced by XCart PR #110.
-
-Repro shape: add a valid line (qty 1), then push it over stock via
-``updateCartQuantity``. The over-stock quantity sits above the product's seeded
-stock but below the platform's 999_999 per-line cap, so the inventory rule fires
-(``PRODUCT_QTY_CHANGED`` / LineItem scope) rather than the line-limit rule.
-Carts are anonymous (random ``ctx.user_id``), matching the other cart suites.
-"""
-
 import allure
 import pytest
 from core.clients import GraphQLClient
@@ -45,11 +31,7 @@ def _has_qty_error(errors: list[dict]) -> bool:
 
 
 def _assert_scoped_to_line(line: dict) -> None:
-    """Defensively confirm the per-line validation errors are scoped to the
-    LineItem (not the cart). The backend may omit objectType/objectId, so only
-    assert linkage when at least one is populated: an error whose objectType
-    names a line item OR whose objectId equals the line's own id.
-    """
+
     errors = line["validationErrors"]
     has_object_type = any(e.get("objectType") for e in errors)
     has_object_id = any(e.get("objectId") for e in errors)
@@ -92,9 +74,7 @@ def _seed_over_stock_line(cart_ops: CartOperations, ctx: Context) -> None:
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Over-stock line should stay invalid with a per-line quantity error")
 def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """VCST-5234 core guard: an over-stock line reports isValid=false + a
-    per-line quantity error. Read per-line only (no cart-level validationErrors
-    field) so nothing re-validates the aggregate — the decisive probe."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step(f"Add {_PRODUCT_ID}×{_VALID_QTY}, then update to {_OVER_STOCK_QTY}"):
@@ -123,9 +103,7 @@ def test_line_item_validation_survives_overstock_update(graphql_client: GraphQLC
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Per-line errors should persist after a subsequent cart change")
 def test_line_item_validation_persists_after_subsequent_change(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """The literal VCST-5234 symptom: per-line errors must NOT disappear after a
-    later cart change. Over-stock a line, then add an unrelated valid line (a
-    save), and confirm the over-stock line is still invalid."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):
@@ -202,10 +180,7 @@ def test_line_item_validation_isolated_across_lines(graphql_client: GraphQLClien
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Cart should expose validationErrors scoped per ruleSet")
 def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """The item over-stock error belongs to the items scope: it surfaces under
-    ruleSet ``*`` (union) and ``items``, but not under ``default``/``shipments``,
-    and an unknown ruleSet returns nothing. The per-line signal stays invalid
-    regardless of which cart-level ruleSet is queried."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):
@@ -241,8 +216,7 @@ def test_cart_validation_ruleset_scoping(graphql_client: GraphQLClient, ctx: Con
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("ruleSet cache should stay isolated within a single request")
 def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """Two ruleSet-scoped validationErrors selections in one request (aliases)
-    must not leak into or poison each other (VCST-4952 / PR #110)."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):
@@ -278,8 +252,7 @@ def test_cart_validation_ruleset_isolation_within_request(graphql_client: GraphQ
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("ruleSet cache should stay isolated across separate requests")
 def test_cart_validation_ruleset_isolation_across_requests(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """Querying one ruleSet must not leak into / poison a subsequent request's
-    ruleSet (each get_cart_validation call is a separate POST)."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):
@@ -308,8 +281,7 @@ def test_cart_validation_ruleset_isolation_across_requests(graphql_client: Graph
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Validation errors should clear after the cart is corrected")
 def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """After correcting the quantity back within stock, both cart-level and
-    per-line validation errors must clear (no stale errors)."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):
@@ -344,9 +316,7 @@ def test_cart_validation_clears_after_correction(graphql_client: GraphQLClient, 
 @allure.feature("Cart / Validation (GraphQL)")
 @allure.title("Validation errors should clear after the over-stock line is removed")
 def test_cart_validation_clears_after_line_removal(graphql_client: GraphQLClient, ctx: Context) -> None:
-    """Complement to correction-by-quantity: an over-stock line reports
-    ``isValid: false`` + per-line errors, then REMOVING that line clears the
-    cart-level and per-line validation errors (the line is simply gone)."""
+
     cart_ops = CartOperations(client=graphql_client)
 
     with allure.step("Create an over-stock line"):


### PR DESCRIPTION
## What

Adds GraphQL/xAPI auto-test coverage for **cart validation errors with ruleSet, per-line and at cart level** — the regression-coverage task **VCST-5240** for bug **VCST-5234** (*per-line `validationErrors` / `isValid` disappear after any cart change*), now fixed (XCart `3.1019.0-pr-124`).

## Changes

- **`gql/fragments/line_item.graphql`** + **`gql/types/line_item.py`** — expose per-line `isValid` / `validationErrors` (reusing the existing `ValidationError` model). Additive — existing cart suites unaffected.
- **`gql/operations/cart_operations.py`** — three read helpers:
  - `get_cart_validation(rule_set=…)` — cart-level `validationErrors(ruleSet:)` + per-line, raw payload.
  - `get_cart_validation_aliased(a, b)` — two ruleSet selections in one request (within-request isolation).
  - `get_cart_line_validation()` — per-line only, **no** cart-level field (the decisive VCST-5234 probe; cart-level selection would re-validate and mask the bug).
- **`tests/graphql/test_cart_validation.py`** — 7 `graphql` cases:
  1. per-line `isValid`/`validationErrors` survive an over-stock quantity update (core guard);
  2. per-line error persists after a subsequent cart change (the literal symptom);
  3. per-line validity isolated across lines (over-stock line invalid, sibling valid);
  4. cart-level ruleSet scoping — error under `*`/`items`, absent under `default`/`shipments`/`foo`; per-line invalid regardless;
  5. within-request ruleSet isolation (aliased `*` vs `shipments`; `foo` vs `*`);
  6. cross-request ruleSet isolation;
  7. errors clear after correcting the quantity.

## Notes

- Over-stock uses an in-stock tracked product pushed to qty `500_000` — above seeded stock, below the `999_999` per-line cap — so the inventory rule (`PRODUCT_QTY_CHANGED`, LineItem scope) fires rather than `LINE_ITEM_LIMIT`. Assertions are structural (no exact prices/messages).
- Anonymous carts (random `ctx.user_id`), matching the existing cart suites; teardown via `delete_cart_after`.

## Verification

`pytest tests/graphql/test_cart_validation.py` → **7 passed** against vcst-qa (fixed XCart build). Existing cart suites (`test_cart_get`, `test_cart_remove_item`) still pass with the extended fragment. `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)