### PR TITLE
test(e2e): replace skip with optional marker on wishlist tests (VCST-…

### DIFF
--- a/tests/e2e/test_wishlist_add_all_to_cart.py
+++ b/tests/e2e/test_wishlist_add_all_to_cart.py
@@ -26,7 +26,7 @@ def _is_cart_from_wishlist_mutation(response: Response) -> bool:
 
 
 @pytest.mark.e2e
-@pytest.mark.skip
+@pytest.mark.optional
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Add products to cart (E2E)")
 @allure.title("Add all wishlist products to cart from list details")

--- a/tests/e2e/test_wishlist_add_product.py
+++ b/tests/e2e/test_wishlist_add_product.py
@@ -55,7 +55,7 @@ def _open_from_pdp(page: Page, global_settings: GlobalSettings) -> str:
 
 
 @pytest.mark.e2e
-@pytest.mark.skip
+@pytest.mark.optional
 @pytest.mark.with_user(_USERNAME)
 @pytest.mark.parametrize(
     "open_add_to_list,source_label",

--- a/tests/e2e/test_wishlist_manage_lists.py
+++ b/tests/e2e/test_wishlist_manage_lists.py
@@ -27,7 +27,7 @@ def _is_wishlist_manage_mutation(response: Response) -> bool:
 
 
 @pytest.mark.e2e
-@pytest.mark.skip
+@pytest.mark.optional
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / List management (E2E)")
 @allure.title("Create, edit, and remove wishlists with Private, Any, and Organization scopes")

--- a/tests/e2e/test_wishlist_remove_product.py
+++ b/tests/e2e/test_wishlist_remove_product.py
@@ -26,7 +26,7 @@ def _is_wishlist_item_mutation(response: Response) -> bool:
 
 
 @pytest.mark.e2e
-@pytest.mark.skip
+@pytest.mark.optional
 @pytest.mark.with_user(_USERNAME)
 @allure.feature("Wishlist / Remove product (E2E)")
 @allure.title("Remove a product from a wishlist via the add-to-list modal")


### PR DESCRIPTION
…5200)

Release 2.51.0 shipped, so wishlist E2E tests no longer need the skip marker. Switch to the optional marker so they run by default and can be excluded with -m 'not optional'.