### PR TITLE
Fix store get_all: use POST /api/stores/search (GET /api/stores removed in Stable 15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ screenshots/
 .serena/
 .claude/settings.local.json
 *.local.md
+/.vs

--- a/restapi/operations/store_operations.py
+++ b/restapi/operations/store_operations.py
@@ -39,8 +39,10 @@ class StoreOperations(RestBaseOperations):
         self._client.put(self._url(self.PATH), json={**existing, **overrides})
 
     def get_all(self) -> list[Store]:
-        response = self._client.get(self._url(self.PATH))
-        return [Store.model_validate(s) for s in response or []]
+        # GET /api/stores was removed in Stable 15; list all stores via POST /api/stores/search.
+        response = self._client.post(self._url(f"{self.PATH}/search"), json={"skip": 0, "take": 1000})
+        results = response.get("results", []) if isinstance(response, dict) else (response or [])
+        return [Store.model_validate(s) for s in results]
 
     def get_by_id(self, store_id: str) -> Store:
         response = self._client.get(self._url(f"{self.PATH}/{store_id}"))


### PR DESCRIPTION
GET /api/stores was removed in Stable 15. Repoint `StoreOperations.get_all()` to `POST /api/stores/search` so `test_store_get_all` passes (was 405 in module auto-tests, e.g. vc-module-store#170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-client compatibility fix with bounded pagination; no auth or production runtime changes.
> 
> **Overview**
> **`StoreOperations.get_all()`** no longer calls removed **GET `/api/stores`** (Stable 15). It now uses **POST `/api/stores/search`** with `skip: 0` and `take: 1000`, reads the `results` array from the search payload, and still returns `list[Store]` so callers like store auto-tests keep the same API.
> 
> **.gitignore** restores ignoring `*.local.md` and adds `/.vs` for local IDE artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2355d296d2e7dd3fc1361a6d9fc8dac7de86e862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->