### PR TITLE
fix(dataset): tolerate missing endpoints on older backends via optional entities

### DIFF
--- a/dataset/data/manifest.json
+++ b/dataset/data/manifest.json
@@ -160,7 +160,8 @@
     "module_id": "VirtoCommerce.Customer",
     "method": "POST",
     "endpoint": "/api/customer/organization-memberships",
-    "payload_type": "single"
+    "payload_type": "single",
+    "optional": true
   },
   {
     "name": "pickup_locations",

--- a/dataset/dataset_manager.py
+++ b/dataset/dataset_manager.py
@@ -8,7 +8,7 @@ from core.clients.rest import RestClient
 from core.global_settings import GlobalSettings
 from core.logger import Logger
 
-from dataset.dataset_seeder import DatasetSeeder, fetch_installed_modules
+from dataset.dataset_seeder import DatasetSeeder, EndpointNotAvailable, fetch_installed_modules
 from dataset.json_loader import load_entity_files
 from dataset.manifest import ManifestEntry, load_manifest
 from dataset.request_builder import build_requests, substitute_env
@@ -118,9 +118,7 @@ class DatasetManager:
         seeder: DatasetSeeder,
     ) -> bool:
         if installed_modules and entry.module_id not in installed_modules:
-            self._logger.warning(
-                f"[yellow]Skipping {entry.name}:[/yellow] module {entry.module_id} is not installed"
-            )
+            self._logger.warning(f"[yellow]Skipping {entry.name}:[/yellow] module {entry.module_id} is not installed")
             return True
         items = self._items_by_entry.get(entry.name)
         if not items:
@@ -135,11 +133,15 @@ class DatasetManager:
                 installed_modules=installed_modules or None,
                 logger=self._logger,
             )
-            seeder.seed(requests)
-        except Exception as e:
-            self._logger.error(
-                f"[red]\\[{entry.name}] Aborted:[/red] {type(e).__name__}: {e}"
+            seeder.seed(requests, optional=entry.optional)
+        except EndpointNotAvailable:
+            self._logger.warning(
+                f"[yellow]Skipping optional {entry.name}:[/yellow] endpoint {entry.endpoint} "
+                f"not available on this backend version (older module than edge)"
             )
+            return True
+        except Exception as e:
+            self._logger.error(f"[red]\\[{entry.name}] Aborted:[/red] {type(e).__name__}: {e}")
             return False
         return True
 

--- a/dataset/dataset_seeder.py
+++ b/dataset/dataset_seeder.py
@@ -1,9 +1,24 @@
 import time
 
+import requests
+
 from core.clients.rest import RestClient
 from core.logger import Logger
 
 from dataset.request_builder import PreparedRequest
+
+
+class EndpointNotAvailable(Exception):
+    """An optional entity's endpoint is absent on the target backend (HTTP 404).
+
+    Signals to the caller that the entity was skipped — not failed — because the installed
+    module version predates this endpoint (e.g. running edge-aware tests against stable).
+    """
+
+
+def _is_not_found(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    return isinstance(exc, requests.HTTPError) and response is not None and response.status_code == 404
 
 
 def fetch_installed_modules(rest_client: RestClient, base_url: str, logger: Logger) -> set[str]:
@@ -26,27 +41,35 @@ class DatasetSeeder:
         self._rest_client = rest_client
         self._logger = logger
 
-    def seed(self, requests: list[PreparedRequest]) -> None:
-        """Send all requests in order. Aborts on the first failure (raises the underlying error)."""
-        for request in requests:
-            self._send(request)
+    def seed(self, requests: list[PreparedRequest], optional: bool = False) -> None:
+        """Send all requests in order. Aborts on the first failure (raises the underlying error).
 
-    def _send(self, request: PreparedRequest) -> None:
+        When `optional` is True, a 404 raises `EndpointNotAvailable` instead of a generic error,
+        so the caller can treat the entity as skipped rather than failed.
+        """
+        for request in requests:
+            self._send(request, optional=optional)
+
+    def _send(self, request: PreparedRequest, optional: bool = False) -> None:
         prefix = f"Seeding \\[{request.label}]"
         start = time.perf_counter()
         try:
             self._dispatch(request)
         except Exception as e:
             elapsed = time.perf_counter() - start
+            if optional and _is_not_found(e):
+                self._logger.warning(
+                    f"{prefix} {request.method} {request.url} [yellow]SKIPPED[/yellow] "
+                    f"\\[{elapsed:.2f}s]: endpoint not available on this backend (HTTP 404)"
+                )
+                raise EndpointNotAvailable(str(e)) from e
             self._logger.error(
                 f"{prefix} {request.method} {request.url} [red]FAILED[/red] "
                 f"\\[{elapsed:.2f}s]: {type(e).__name__}: {e}"
             )
             raise
         elapsed = time.perf_counter() - start
-        self._logger.info(
-            f"{prefix} {request.method} {request.url} [green]DONE[/green] \\[{elapsed:.2f}s]"
-        )
+        self._logger.info(f"{prefix} {request.method} {request.url} [green]DONE[/green] \\[{elapsed:.2f}s]")
 
     def _dispatch(self, request: PreparedRequest) -> None:
         match request.method:

--- a/dataset/manifest.py
+++ b/dataset/manifest.py
@@ -18,6 +18,7 @@ class ManifestEntry:
     endpoint: str
     payload_type: PayloadType
     parent_ref_field: str | None = None
+    optional: bool = False
 
 
 def load_manifest(path: Path) -> list[ManifestEntry]:
@@ -48,9 +49,7 @@ def load_manifest(path: Path) -> list[ManifestEntry]:
 def _validate(entry: ManifestEntry, index: int, path: Path) -> None:
     location = f"manifest entry #{index} ({entry.name}) in {path}"
     if entry.method not in _VALID_METHODS:
-        raise ValueError(
-            f"Invalid method {entry.method!r} in {location}; expected one of {sorted(_VALID_METHODS)}"
-        )
+        raise ValueError(f"Invalid method {entry.method!r} in {location}; expected one of {sorted(_VALID_METHODS)}")
     if entry.payload_type not in _VALID_PAYLOAD_TYPES:
         raise ValueError(
             f"Invalid payload_type {entry.payload_type!r} in {location}; "


### PR DESCRIPTION
## Problem

Auto-tests run the same `dev` test module against different backend versions (stable vs edge). When run against a **stable** platform whose `VirtoCommerce.Customer` module is **older than edge**, seeding `organization_memberships` via `POST /api/customer/organization-memberships` returns **404** — the module is installed, but that endpoint doesn't exist yet in the older version.

The seed CLI does `sys.exit(1)` on any failed entity, so **CI died at the seed step before pytest ran** — failing every DB-matrix job. See failing run: https://github.com/VirtoCommerce/vc-modules/actions/runs/27952025991

The existing module-presence skip can't catch this: the module *is* installed; only the endpoint is absent.

## Fix

Add an `optional` flag to manifest entries. When set, a **404** during seeding is logged as `SKIPPED` and counted as success instead of failing the entity. All other errors (400/401/403/5xx, build errors) still abort as before.

- `manifest.py` — new `optional: bool = False` field on `ManifestEntry`
- `dataset_seeder.py` — `EndpointNotAvailable` exception + `_is_not_found()`; `seed(..., optional=)` raises it on a 404 and logs yellow `SKIPPED`
- `dataset_manager.py` — catches `EndpointNotAvailable`, logs the skip, returns success (no `exit 1`)
- `data/manifest.json` — `organization_memberships` marked `"optional": true`

This reuses the project's existing `optional` vocabulary (the `optional` pytest marker / `-m 'not optional'` stable runs). On edge the endpoint exists and seeds normally; on stable it's skipped.

**Going forward:** mark any new edge-only dataset entity `"optional": true` so stable runs don't break.

## Trade-off

The skip keys on a 404, so a genuine 404 regression on *edge* would also be silently skipped. If strict version gating is preferred (skip only when the installed module version is below a threshold), that can be added as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)