### PR TITLE
Revert "Harden test_index_cancel against Hangfire monitoring-API race…

### DIFF
--- a/tests/restapi/search/test_search.py
+++ b/tests/restapi/search/test_search.py
@@ -13,7 +13,6 @@ import time
 
 import allure
 import pytest
-import requests
 
 from core.clients.rest import RestClient
 
@@ -89,18 +88,7 @@ def test_index_cancel(rest_client: RestClient, backend_base_url: str) -> None:
 
     if task_id:
         with allure.step(f"GET /api/search/indexes/tasks/{task_id}/cancel"):
-            try:
-                rest_client.get(f"{backend_base_url}/api/search/indexes/tasks/{task_id}/cancel")
-            except requests.HTTPError as exc:
-                # Cancellation inspects the Hangfire monitoring API, which transiently raises
-                # while a freshly-enqueued job is still transitioning between states
-                # (the "ServerName"-key race). This smoke test only verifies the cancel
-                # endpoint is reachable, so a transient 5xx is tolerated; 4xx/route errors
-                # (a real regression) still fail the test.
-                response = getattr(exc, "response", None)
-                if response is None or response.status_code < 500:
-                    raise
-                allure.attach(str(exc), "transient cancel race (tolerated)", allure.attachment_type.TEXT)
+            rest_client.get(f"{backend_base_url}/api/search/indexes/tasks/{task_id}/cancel")
 
 
 @pytest.mark.restapi


### PR DESCRIPTION
… (#180)"

This reverts commit b9f3335a72cd7d5b7195240b60cc6c06f8378c8a.