### PR TITLE
VCST-5510: Enable running tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings==2.13.1",
     "pytest==9.0.3",
     "pytest-playwright==0.7.2",
+    "pytest-xdist==3.8.0",
     "requests==2.32.5",
     "rich==14.3.3",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,25 +25,6 @@ _FEATURE_MARKERS = ["quantity_control", "range_filter_type", "checkout_mode"]
 _INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*]')
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Force every test signed in as the same backend user onto one xdist worker.
-
-    Tests marked `with_user(username)` mutate that user's real, persistent
-    server-side state (cart, wishlist, saved addresses) — running two of them
-    concurrently on different workers races the same account. Tests with no
-    `with_user` marker get a fresh random user_id per test (see
-    Context.from_dataset) and have no shared state to race, so they're left
-    ungrouped and free to load-balance across all workers.
-
-    Only takes effect under `pytest -n ... --dist loadgroup`; the group marker
-    is a no-op otherwise.
-    """
-    for item in items:
-        marker = item.get_closest_marker("with_user")
-        if marker and marker.args:
-            item.add_marker(pytest.mark.xdist_group(name=f"user-{marker.args[0]}"))
-
-
 def pytest_runtest_setup(item: pytest.Item) -> None:
     for marker_name in _FEATURE_MARKERS:
         marker = item.get_closest_marker(marker_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,25 @@ _FEATURE_MARKERS = ["quantity_control", "range_filter_type", "checkout_mode"]
 _INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*]')
 
 
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Force every test signed in as the same backend user onto one xdist worker.
+
+    Tests marked `with_user(username)` mutate that user's real, persistent
+    server-side state (cart, wishlist, saved addresses) — running two of them
+    concurrently on different workers races the same account. Tests with no
+    `with_user` marker get a fresh random user_id per test (see
+    Context.from_dataset) and have no shared state to race, so they're left
+    ungrouped and free to load-balance across all workers.
+
+    Only takes effect under `pytest -n ... --dist loadgroup`; the group marker
+    is a no-op otherwise.
+    """
+    for item in items:
+        marker = item.get_closest_marker("with_user")
+        if marker and marker.args:
+            item.add_marker(pytest.mark.xdist_group(name=f"user-{marker.args[0]}"))
+
+
 def pytest_runtest_setup(item: pytest.Item) -> None:
     for marker_name in _FEATURE_MARKERS:
         marker = item.get_closest_marker(marker_name)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only change with no default behavior change until parallel flags are used; main risk is accidental parallel runs of `serial` tests if workers are enabled without filtering.
> 
> **Overview**
> Adds **`pytest-xdist==3.8.0`** to project dependencies so pytest can distribute tests across workers (typical usage: `pytest -n auto` or a fixed worker count).
> 
> No pytest `addopts` or CI workflow changes are in this diff—parallel execution is opt-in at the command line. Existing **`serial`** marker documentation still applies for tests that mutate global state and must not run concurrently with other tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f327082aeb523949a2eb8926040c945a920e34ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->