### PR TITLE
VCST-5510: Update workflow and module versions

### DIFF
--- a/.github/workflows/auto-tests.yml
+++ b/.github/workflows/auto-tests.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   e2e-tests:
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.42
     with:
       installModules: 'false'
       installCustomModule: 'false'

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1043.0",
+  "PlatformVersion": "3.1058.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1043.0",
+  "PlatformImageTag": "3.1058.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -19,7 +19,7 @@
       "Modules": [
         {
           "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.ElasticSearch",
@@ -27,7 +27,7 @@
         },
         {
           "Id": "VirtoCommerce.XFrontend",
-          "Version": "3.1003.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.OpenTelemetry",
@@ -39,11 +39,11 @@
         },
         {
           "Id": "VirtoCommerce.SystemOperations",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Quote",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.PriceExportImport",
@@ -63,11 +63,11 @@
         },
         {
           "Id": "VirtoCommerce.MarketingExperienceApi",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.BuilderIO",
@@ -75,11 +75,11 @@
         },
         {
           "Id": "VirtoCommerce.XRecommend",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.OpenIdConnectModule",
@@ -99,7 +99,7 @@
         },
         {
           "Id": "VirtoCommerce.BackInStock",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.OpenSearch",
@@ -111,7 +111,7 @@
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.EnvironmentsCompare",
@@ -123,7 +123,7 @@
         },
         {
           "Id": "VirtoCommerce.ProductSnapshot",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.Core",
@@ -175,7 +175,7 @@
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
-          "Version": "3.1003.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.LuceneSearch",
@@ -183,7 +183,7 @@
         },
         {
           "Id": "VirtoCommerce.Store",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
@@ -191,11 +191,11 @@
         },
         {
           "Id": "VirtoCommerce.Payment",
-          "Version": "3.1004.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Tax",
-          "Version": "3.1003.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.Content",
@@ -203,7 +203,7 @@
         },
         {
           "Id": "VirtoCommerce.Shipping",
-          "Version": "3.1005.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPersonalization",
@@ -219,11 +219,11 @@
         },
         {
           "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1003.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.FileExperienceApi",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPublishing",
@@ -235,11 +235,11 @@
         },
         {
           "Id": "VirtoCommerce.PushMessages",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -259,7 +259,7 @@
         },
         {
           "Id": "VirtoCommerce.XCMS",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Return",
@@ -271,7 +271,7 @@
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",
-          "Version": "3.1004.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Inventory",
@@ -279,7 +279,7 @@
         },
         {
           "Id": "VirtoCommerce.Search",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Marketing",
@@ -291,39 +291,39 @@
         },
         {
           "Id": "VirtoCommerce.News",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.TaskManagement",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1013.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1034.0"
+          "Version": "3.1040.0"
         },
         {
           "Id": "VirtoCommerce.BackupRestore",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.PageBuilderModule",
-          "Version": "3.1020.0"
+          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1011.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.Customer",
-          "Version": "3.1014.0"
+          "Version": "3.1022.0"
         },
         {
           "Id": "VirtoCommerce.UCP",
-          "Version": "3.1001.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.EventBus",
@@ -331,19 +331,19 @@
         },
         {
           "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1010.0"
+          "Version": "3.1013.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1011.0"
+          "Version": "3.1015.0"
         },
         {
           "Id": "VirtoCommerce.Cart",
-          "Version": "3.1007.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1007.0"
+          "Version": "3.1008.0"
         },
         {
           "Id": "VirtoCommerce.Assets",
@@ -351,11 +351,11 @@
         },
         {
           "Id": "VirtoCommerce.Orders",
-          "Version": "3.1012.0"
+          "Version": "3.1013.0"
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1026.0"
+          "Version": "3.1029.0"
         }
       ]
     }

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -18,6 +18,10 @@
       ],
       "Modules": [
         {
+          "Id": "VirtoCommerce.BackgroundJobs",
+          "Version": "3.1050.0"
+        },
+        {
           "Id": "VirtoCommerce.Loyalty",
           "Version": "3.1004.0"
         },

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,21 +1,28 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058",
+  "PlatformVersion": "3.1058.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1058.0",
-  "PlatformAssetUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.1059.0-alpha.13363-vcst-5387-top-level-catalog-assets.zip",
+  "PlatformAssetUrl": "",
   "Sources": [
     {
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": []
+      "Modules": [
+        {
+          "Id": "VirtoCommerce.Cart",
+          "BlobName": "VirtoCommerce.Cart_3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope.zip"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "BlobName": "VirtoCommerce.XCart_3.1029.0-alpha.270-vcst-5332-customer-wishlist-sharing-scope.zip"
+        }
+      ]
     },
     {
       "Name": "GithubReleases",
-      "ModuleSources": [
-        "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
-      ],
+      "ModuleSources": ["https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"],
       "Modules": [
         {
           "Id": "VirtoCommerce.Loyalty",
@@ -26,24 +33,12 @@
           "Version": "3.806.0"
         },
         {
-          "Id": "VirtoCommerce.XFrontend",
-          "Version": "3.1006.0"
-        },
-        {
           "Id": "VirtoCommerce.OpenTelemetry",
           "Version": "3.1000.0"
         },
         {
           "Id": "VirtoCommerce.Contentful",
           "Version": "3.1001.0"
-        },
-        {
-          "Id": "VirtoCommerce.SystemOperations",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Quote",
-          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.PriceExportImport",
@@ -62,23 +57,7 @@
           "Version": "3.1001.0"
         },
         {
-          "Id": "VirtoCommerce.MarketingExperienceApi",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1000.0"
-        },
-        {
           "Id": "VirtoCommerce.BuilderIO",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.XRecommend",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Skyflow",
           "Version": "3.1004.0"
         },
         {
@@ -98,10 +77,6 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.BackInStock",
-          "Version": "3.1002.0"
-        },
-        {
           "Id": "VirtoCommerce.OpenSearch",
           "Version": "3.1001.0"
         },
@@ -110,20 +85,12 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1003.0"
-        },
-        {
           "Id": "VirtoCommerce.EnvironmentsCompare",
           "Version": "3.1001.0"
         },
         {
           "Id": "VirtoCommerce.SqlQueries",
           "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.ProductSnapshot",
-          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.Core",
@@ -174,56 +141,24 @@
           "Version": "3.1003.0"
         },
         {
-          "Id": "VirtoCommerce.AzureSearch",
-          "Version": "3.1005.0"
-        },
-        {
           "Id": "VirtoCommerce.LuceneSearch",
           "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
           "Version": "4.1002.0"
         },
         {
-          "Id": "VirtoCommerce.Payment",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Tax",
-          "Version": "3.1005.0"
-        },
-        {
           "Id": "VirtoCommerce.Content",
           "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Shipping",
-          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPersonalization",
           "Version": "3.1003.0"
         },
         {
-          "Id": "VirtoCommerce.Pages",
-          "Version": "3.1008.0"
-        },
-        {
           "Id": "VirtoCommerce.Sitemaps",
           "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.FileExperienceApi",
-          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPublishing",
@@ -232,14 +167,6 @@
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
           "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.PushMessages",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -258,10 +185,6 @@
           "Version": "3.1001.0"
         },
         {
-          "Id": "VirtoCommerce.XCMS",
-          "Version": "3.1004.0"
-        },
-        {
           "Id": "VirtoCommerce.Return",
           "Version": "3.1001.0"
         },
@@ -270,16 +193,8 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.CustomerReviews",
-          "Version": "3.1006.0"
-        },
-        {
           "Id": "VirtoCommerce.Inventory",
           "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Search",
-          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Marketing",
@@ -290,11 +205,135 @@
           "Version": "3.1002.0"
         },
         {
+          "Id": "VirtoCommerce.EventBus",
+          "Version": "3.1010.0"
+        },
+        {
+          "Id": "VirtoCommerce.Assets",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Search",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Store",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackupRestore",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1013.0"
+        },
+        {
+          "Id": "VirtoCommerce.AzureSearch",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackgroundJobs",
+          "Version": "3.1050.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProductSnapshot",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.UCP",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackInStock",
+          "Version": "3.1002.0"
+        },
+        {
           "Id": "VirtoCommerce.News",
           "Version": "3.1005.0"
         },
         {
+          "Id": "VirtoCommerce.XCMS",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Skyflow",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.MarketingExperienceApi",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Quote",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileExperienceApi",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.XOrder",
+          "Version": "3.1008.0"
+        },
+        {
+          "Id": "VirtoCommerce.XRecommend",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.PushMessages",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.WhiteLabeling",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Contracts",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
+          "Version": "3.1003.0"
+        },
+        {
           "Id": "VirtoCommerce.TaskManagement",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.PageBuilderModule",
+          "Version": "3.1020.0"
+        },
+        {
+          "Id": "VirtoCommerce.SalesRep",
+          "Version": "3.1000.0"
+        },
+        {
+          "Id": "VirtoCommerce.Shipping",
+          "Version": "3.1007.0"
+        },
+        {
+          "Id": "VirtoCommerce.Tax",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.Payment",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.SystemOperations",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.Notifications",
+          "Version": "3.1013.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pages",
+          "Version": "3.1008.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pricing",
           "Version": "3.1005.0"
         },
         {
@@ -302,16 +341,12 @@
           "Version": "3.1016.0"
         },
         {
+          "Id": "VirtoCommerce.XFrontend",
+          "Version": "3.1005.0"
+        },
+        {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1041.0-alpha.2564-vcst-5387-stream-catalog-binaries"
-        },
-        {
-          "Id": "VirtoCommerce.BackupRestore",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.PageBuilderModule",
-          "Version": "3.1021.0"
+          "Version": "3.1040.0"
         },
         {
           "Id": "VirtoCommerce.XCatalog",
@@ -319,43 +354,15 @@
         },
         {
           "Id": "VirtoCommerce.Customer",
-          "Version": "3.1022.0"
-        },
-        {
-          "Id": "VirtoCommerce.UCP",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.EventBus",
-          "Version": "3.1010.0"
-        },
-        {
-          "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1013.0"
+          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
           "Version": "3.1015.0"
         },
         {
-          "Id": "VirtoCommerce.Cart",
-          "Version": "3.1009.0"
-        },
-        {
-          "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1008.0"
-        },
-        {
-          "Id": "VirtoCommerce.Assets",
+          "Id": "VirtoCommerce.CustomerReviews",
           "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCart",
-          "Version": "3.1029.0"
         }
       ]
     }

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -9,12 +9,7 @@
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": [
-         {
-          "Id": "VirtoCommerce.XCart",
-          "BlobName": "VirtoCommerce.XCart_3.1029.0-alpha.270-vcst-5332-customer-wishlist-sharing-scope.zip"
-        }
-      ]
+      "Modules": []
     },
     {
       "Name": "GithubReleases",
@@ -28,7 +23,7 @@
         },
         {
           "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.ElasticSearch",
@@ -361,6 +356,10 @@
         {
           "Id": "VirtoCommerce.Orders",
           "Version": "3.1012.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "Version": "3.1029.0"
         }
       ]
     }

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -187,7 +187,7 @@
         },
         {
           "Id": "VirtoCommerce.Store",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
@@ -303,7 +303,7 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1013.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.Catalog",

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,36 +1,33 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058.0",
+  "PlatformVersion": "3.1048.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1058.0",
+  "PlatformImageTag": "3.1048.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": [
-        {
-          "Id": "VirtoCommerce.Cart",
-          "BlobName": "VirtoCommerce.Cart_3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope.zip"
-        },
-        {
-          "Id": "VirtoCommerce.XCart",
-          "BlobName": "VirtoCommerce.XCart_3.1029.0-alpha.270-vcst-5332-customer-wishlist-sharing-scope.zip"
-        }
-      ]
+      "Modules": []
     },
     {
       "Name": "GithubReleases",
-      "ModuleSources": ["https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"],
+      "ModuleSources": [
+        "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
+      ],
       "Modules": [
         {
           "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1005.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"
+        },
+        {
+          "Id": "VirtoCommerce.XFrontend",
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.OpenTelemetry",
@@ -38,6 +35,14 @@
         },
         {
           "Id": "VirtoCommerce.Contentful",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.SystemOperations",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Quote",
           "Version": "3.1001.0"
         },
         {
@@ -57,8 +62,24 @@
           "Version": "3.1001.0"
         },
         {
+          "Id": "VirtoCommerce.MarketingExperienceApi",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.WhiteLabeling",
+          "Version": "3.1002.0"
+        },
+        {
           "Id": "VirtoCommerce.BuilderIO",
           "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.XRecommend",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.Skyflow",
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.OpenIdConnectModule",
@@ -77,11 +98,19 @@
           "Version": "3.1002.0"
         },
         {
+          "Id": "VirtoCommerce.BackInStock",
+          "Version": "3.1001.0"
+        },
+        {
           "Id": "VirtoCommerce.OpenSearch",
           "Version": "3.1001.0"
         },
         {
           "Id": "VirtoCommerce.CyberSourcePayment",
+          "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
           "Version": "3.1002.0"
         },
         {
@@ -91,6 +120,10 @@
         {
           "Id": "VirtoCommerce.SqlQueries",
           "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProductSnapshot",
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Core",
@@ -141,23 +174,55 @@
           "Version": "3.1003.0"
         },
         {
+          "Id": "VirtoCommerce.AzureSearch",
+          "Version": "3.1003.0"
+        },
+        {
           "Id": "VirtoCommerce.LuceneSearch",
           "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Store",
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.GoogleEcommerceAnalytics",
           "Version": "4.1002.0"
         },
         {
+          "Id": "VirtoCommerce.Payment",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Tax",
+          "Version": "3.1003.0"
+        },
+        {
           "Id": "VirtoCommerce.Content",
           "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Shipping",
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPersonalization",
           "Version": "3.1003.0"
         },
         {
+          "Id": "VirtoCommerce.Pages",
+          "Version": "3.1008.0"
+        },
+        {
           "Id": "VirtoCommerce.Sitemaps",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pricing",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.FileExperienceApi",
           "Version": "3.1003.0"
         },
         {
@@ -167,6 +232,14 @@
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
           "Version": "3.1002.0"
+        },
+        {
+          "Id": "VirtoCommerce.PushMessages",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Contracts",
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -185,6 +258,10 @@
           "Version": "3.1001.0"
         },
         {
+          "Id": "VirtoCommerce.XCMS",
+          "Version": "3.1003.0"
+        },
+        {
           "Id": "VirtoCommerce.Return",
           "Version": "3.1001.0"
         },
@@ -193,8 +270,16 @@
           "Version": "3.1002.0"
         },
         {
+          "Id": "VirtoCommerce.CustomerReviews",
+          "Version": "3.1004.0"
+        },
+        {
           "Id": "VirtoCommerce.Inventory",
           "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Search",
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.Marketing",
@@ -205,164 +290,72 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.EventBus",
-          "Version": "3.1010.0"
-        },
-        {
-          "Id": "VirtoCommerce.Assets",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Search",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackupRestore",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
-        },
-        {
-          "Id": "VirtoCommerce.AzureSearch",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackgroundJobs",
-          "Version": "3.1050.0"
-        },
-        {
-          "Id": "VirtoCommerce.ProductSnapshot",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.UCP",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackInStock",
-          "Version": "3.1002.0"
-        },
-        {
           "Id": "VirtoCommerce.News",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCMS",
           "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.MarketingExperienceApi",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Quote",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.FileExperienceApi",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1008.0"
-        },
-        {
-          "Id": "VirtoCommerce.XRecommend",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.PushMessages",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.TaskManagement",
-          "Version": "3.1005.0"
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1013.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1034.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackupRestore",
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.PageBuilderModule",
           "Version": "3.1020.0"
         },
         {
-          "Id": "VirtoCommerce.SalesRep",
-          "Version": "3.1000.0"
-        },
-        {
-          "Id": "VirtoCommerce.Shipping",
-          "Version": "3.1007.0"
-        },
-        {
-          "Id": "VirtoCommerce.Tax",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Payment",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.SystemOperations",
-          "Version": "3.1002.0"
-        },
-        {
-          "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1013.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pages",
-          "Version": "3.1008.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1016.0"
-        },
-        {
-          "Id": "VirtoCommerce.XFrontend",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
-        },
-        {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1016.0"
+          "Version": "3.1011.0"
         },
         {
           "Id": "VirtoCommerce.Customer",
-          "Version": "3.1021.0"
+          "Version": "3.1014.0"
+        },
+        {
+          "Id": "VirtoCommerce.UCP",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.EventBus",
+          "Version": "3.1010.0"
+        },
+        {
+          "Id": "VirtoCommerce.Notifications",
+          "Version": "3.1010.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1015.0"
+          "Version": "3.1011.0"
         },
         {
-          "Id": "VirtoCommerce.CustomerReviews",
+          "Id": "VirtoCommerce.Cart",
+          "Version": "3.1009.0"
+        },
+        {
+          "Id": "VirtoCommerce.XOrder",
+          "Version": "3.1007.0"
+        },
+        {
+          "Id": "VirtoCommerce.Assets",
           "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1012.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "Version": "3.102690"
         }
       ]
     }

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,9 +1,9 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058.0",
+  "PlatformVersion": "3.1058",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1058.0",
-  "PlatformAssetUrl": "",
+  "PlatformAssetUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.1059.0-alpha.13363-vcst-5387-top-level-catalog-assets.zip",
   "Sources": [
     {
       "Name": "AzureBlob",
@@ -67,7 +67,7 @@
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1003.0"
+          "Version": "3.1000.0"
         },
         {
           "Id": "VirtoCommerce.BuilderIO",
@@ -303,7 +303,7 @@
         },
         {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
+          "Version": "3.1041.0-alpha.2564-vcst-5387-stream-catalog-binaries"
         },
         {
           "Id": "VirtoCommerce.BackupRestore",

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -359,7 +359,7 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.102690"
+          "Version": "3.1029.0"
         }
       ]
     }

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -9,7 +9,12 @@
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": []
+      "Modules": [
+         {
+          "Id": "VirtoCommerce.XCart",
+          "BlobName": "VirtoCommerce.XCart_3.1029.0-alpha.270-vcst-5332-customer-wishlist-sharing-scope.zip"
+        }
+      ]
     },
     {
       "Name": "GithubReleases",
@@ -356,10 +361,6 @@
         {
           "Id": "VirtoCommerce.Orders",
           "Version": "3.1012.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCart",
-          "Version": "3.1029.0"
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Platform and core module version bumps can change test-environment behavior and surface incompatibilities across GraphQL, REST, and e2e suites.
> 
> **Overview**
> Bumps the auto-tests reusable workflow and the backend package manifest used by CI test environments.
> 
> Updates `auto-tests.yml` to call `pytest-tests.yml@v3.800.42`. In `backend-packages.json`, raises the platform to **3.1048.0**, adds **`VirtoCommerce.BackgroundJobs` 3.1050.0**, and bumps `Loyalty`, `Store`, `Xapi`, `Cart`, and `XCart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2af6a87332712d664061f78e51020e967f3579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->